### PR TITLE
Improve the chat UI

### DIFF
--- a/web-app/src/assets/jss/material-kit-react/components/chatStyle.js
+++ b/web-app/src/assets/jss/material-kit-react/components/chatStyle.js
@@ -3,11 +3,28 @@ const marginTop = 5;
 const message = {
    position: "relative",
    float: "left",
-   backgroundColor: "rgb(62,64,66)",
+   color: "black",
+   backgroundColor: "rgb(228,230,235)",
    maxWidth: "80%",
    padding: "8px",
    margin: "0px 6px 5px 2px",
    borderRadius: "15px"
+};
+
+const messageHero = {
+   ...message,
+   float: "right",
+   backgroundColor: "rgb(0,132,255)",
+   color: "white",
+};
+
+const messageSystem = {
+   maxWidth: "100%",
+   background: "none",
+   color: "white",
+   padding: "4px",
+   margin: "0px",
+   width: "100%",
 };
 
 const chatStyle = {
@@ -35,41 +52,21 @@ const chatStyle = {
       ...message,
       borderRadius: "4px 15px 15px 15px"
    },
-   messageHero: {
-      ...message,
-      float: "right",
-      backgroundColor: "rgb(0,132,255)"
-   },
+   messageHero,
    messageStartHero: {
-      ...message,
+      ...messageHero,
       borderRadius: "15px 15px 4px 15px",
-      float: "right",
-      backgroundColor: "rgb(0,132,255)"
    },
    messageMidHero: {
-      ...message,
+      ...messageHero,
       borderRadius: "15px 4px 4px 15px",
-      float: "right",
-      backgroundColor: "rgb(0,132,255)"
    },
    messageEndHero: {
-      ...message,
+      ...messageHero,
       borderRadius: "15px 4px 15px 15px",
-      float: "right",
-      backgroundColor: "rgb(0,132,255)"
    },
-   Server: {
-      color: "yellow",
-      fontWeight: "bold"
-   },
-   Game: {
-      color: "yellow",
-      fontWeight: "bold"
-   },
-   opponent: {
-      color: "red",
-      fontWeight: "bold"
-   }
+   Server: messageSystem,
+   Game: messageSystem,
 };
 
 export default chatStyle;

--- a/web-app/src/components/Chat/Messages.js
+++ b/web-app/src/components/Chat/Messages.js
@@ -4,6 +4,7 @@ import PropTypes from "prop-types";
 import { withStyles } from "@material-ui/core/styles";
 import chatStyle from "assets/jss/material-kit-react/components/chatStyle.js";
 
+const DRAW_PHASE_MESSAGE = /set the phase to Draw./;
 class Messages extends PureComponent {
    render() {
       const { classes, messages, hero } = this.props;
@@ -25,13 +26,18 @@ class Messages extends PureComponent {
          else if (messageAbove) section = "End";
          else if (messageBelow) section = "Start";
 
+         const className = classes["message" + section + (authorIsHero ? "Hero" : "")] +
+            (classes[author] ? ` ${classes[author]}` :  "");
          messageList.push(
             <div className={classes.messageContainer} key={i}>
-               <div className={classes["message" + section + (authorIsHero ? "Hero" : "")]}>
-                  {authorIsHero ? "" : <span className={classes[author] || classes.opponent}>{author}:</span>} {content}
+               <div className={className}>
+                  {content}
                </div>
             </div>
          );
+         if (author === 'Server' && DRAW_PHASE_MESSAGE.test(content)) {
+            messageList.push(<hr style={{width: "80%", margin: "10px auto"}} />);
+         }
       }
 
       return messageList;


### PR DESCRIPTION
Fixes #143

- change opponent's message bubbles background/foreground colors to match FB Messenger's
- remove background from system messages and make denser
- add horizontal rule before draw phases to segment out turns

<img width="331" alt="Screen Shot 2021-07-21 at 16 38 16" src="https://user-images.githubusercontent.com/117249/126573265-6730f395-1748-41b2-83ea-0ef5f3959847.png">
