### PR TITLE
Fix concede button being too wide

### DIFF
--- a/web-app/src/views/Game/Battlefield/RightTools/StandardTools/ConcedeButton.js
+++ b/web-app/src/views/Game/Battlefield/RightTools/StandardTools/ConcedeButton.js
@@ -12,7 +12,7 @@ class ConcedeButton extends PureComponent {
       const func = concessionLink ? () => quitGame(this.context) : () => concedeGame(this.context);
 
       return (
-         <Button color={color} fullWidth round href={concessionLink ? concessionLink : undefined} onClick={func} style={{ marginBottom: "15px" }}>
+         <Button color={color} round href={concessionLink ? concessionLink : undefined} onClick={func} style={{ marginBottom: "15px" }}>
             {concessionLink ? "Quit" : "Concede Game"}
          </Button>
       );


### PR DESCRIPTION
Point one from #155 

**https://github.com/acpennington/GoatController/issues/155#issuecomment-884647512**

<img width="194" alt="Screen Shot 2021-07-21 at 21 31 35" src="https://user-images.githubusercontent.com/117249/126590217-c6c10a4d-1996-4251-9647-c28eb05e1566.png">

(no more scroll bar)


---

**TESTED=** tried the window on various screen sizes and the scrollbar remained absent