### PR TITLE
Fix counters to actually be circular

### DIFF
--- a/web-app/src/assets/jss/material-kit-react/components/yugiohCardStyle.js
+++ b/web-app/src/assets/jss/material-kit-react/components/yugiohCardStyle.js
@@ -177,14 +177,17 @@ const cardStyle = {
       ...zoneLabel,
       filter: "",
       padding: "15%",
-      borderRadius: "100%",
+      borderRadius: "50%",
+      width: "2em",
+      height: "2em",
       backgroundColor: "rgba(0,120,0,0.72)"
    },
    zoneLabelVillainCounters: {
       ...zoneLabel,
       filter: "",
-      padding: "15%",
-      borderRadius: "100%",
+      borderRadius: "50%",
+      width: "2em",
+      height: "2em",
       backgroundColor: "rgba(0,120,0,0.72)",
       transform: "translate(-50%, -50%) rotate(180deg)"
    },


### PR DESCRIPTION
With this change, counters stay the same size from 0-99. The existing code has smaller, non-circular counts below 10. Note that there is no difference between `border-radius` 100% and 50%, but 50% is more typically used to for making things circular and technically is one less byte to ship over the wire! ;)

**Before:**

![Screen Shot 2021-07-24 at 20 09 43](https://user-images.githubusercontent.com/117249/126886460-0a88f030-7a0f-451d-9c60-46a3c3caaf66.png)

**After:**

![Screen Shot 2021-07-24 at 20 09 04](https://user-images.githubusercontent.com/117249/126886468-71984301-fdbe-41a7-9653-5301c848ae3e.png)

Behavior for the old counters was to become a sideways oval at 100, with the new code the counter stays the same size and the text just escapes the box. If we care about supporting counters that high (why lol?) we could programmatically change the text size, but that's not covered in this PR.

