### PR TITLE
Cap wall post width and add space

### DIFF
--- a/web-app/src/assets/jss/material-kit-react/views/wall.js
+++ b/web-app/src/assets/jss/material-kit-react/views/wall.js
@@ -3,8 +3,9 @@ import tooltip from "../tooltipsStyle.js";
 const wallStyle = {
    bigContainer: {
       width: "calc(100% - 250px)",
+      maxWidth: "690px",
       position: "relative",
-      float: "right"
+      left: "275px"
    },
    container: {
       overflowY: "auto",


### PR DESCRIPTION
Lines which are too long are hard to read.

**Before** -> **After**

![Screen Shot 2021-07-24 at 20 37 08](https://user-images.githubusercontent.com/117249/126886963-ca99a6d4-8a3a-4d18-9c39-7d4c7ff0cd0f.png)

I would also like to shift the posts and the `Posts By` selector up 40px so that the top of the post box matches the top of the sidebar (with the `Posts By` selector on top) but I am too lazy to figure out how to make it work on small screen sizes without running into the header.

TESTED= adjusted window to various screen sizes
