### PR TITLE
Polish battle visualization

### DIFF
--- a/web-app/src/assets/jss/material-kit-react/components/yugiohCardStyle.js
+++ b/web-app/src/assets/jss/material-kit-react/components/yugiohCardStyle.js
@@ -209,9 +209,17 @@ const cardStyle = {
       animationTimingFunction: "linear",
       animationIterationCount: "infinite"
    },
+   battleImgContainer: {
+      display: "flex",
+      justifyContent: "center",
+      alignItems: "center",
+      width: "100%",
+      height: "100%",
+      zIndex: 1,
+   },
    battleImg: {
       opacity: 0.9,
-      width: "100%"
+      width: "90%"
    }
 };
 

--- a/web-app/src/components/YugiohCard/CardArt.js
+++ b/web-app/src/components/YugiohCard/CardArt.js
@@ -28,7 +28,7 @@ class CardArt extends PureComponent {
          <Fragment>
             <div className={classes.art} style={{ backgroundImage: 'url("/cards/art/' + compress(name) + '.jpg")' }}>
                {battle && (
-                  <div style={{ position: "absolute", top: 0 }}>
+                  <div className={classes.battleImgContainer} style={{ position: "absolute", top: 0, background: "rgba(0,0,0,0.5)" }}>
                      <img src={"/battle/" + battle + ".png"} className={classes.battleImg} alt={battle} />
                   </div>
                )}

--- a/web-app/src/components/YugiohCard/YugiohCard.js
+++ b/web-app/src/components/YugiohCard/YugiohCard.js
@@ -194,8 +194,8 @@ function YugiohCard({ height, notFull, player, row, zone, cardName, modal, isHer
             />
          )}
          {!blank && card && card.battle && facedown && (
-            <div>
-               <img src={"/battle/" + card.battle + ".png"} className={classes.battleImg} alt={card.battle} style={{ marginTop: "20%" }} />
+            <div className={classes.battleImgContainer}>
+               <img src={"/battle/" + card.battle + ".png"} className={classes.battleImg} alt={card.battle} />
             </div>
          )}
          <ZoneLabel


### PR DESCRIPTION
- actually center shield when in face down defense position
- add opacity to image background to avoid jumbling together the card art and the icon
- reduce image sizes to avoid obscuring so much of the card and to give more breathing room

**Before** -> **After**
![Screen Shot 2021-07-24 at 21 11 30](https://user-images.githubusercontent.com/117249/126887476-cc4ad8de-0449-47a3-b384-60752d4da25d.png) ![Screen Shot 2021-07-24 at 21 11 23](https://user-images.githubusercontent.com/117249/126887478-c13c461e-5dcf-4d8c-8f4e-16ef65342728.png)

 ![Screen Shot 2021-07-24 at 21 10 56](https://user-images.githubusercontent.com/117249/126887480-d8e36ee8-6b3d-4085-b5cd-d55e7e5bef22.png) ![Screen Shot 2021-07-24 at 21 11 00](https://user-images.githubusercontent.com/117249/126887479-a0430087-6617-4b51-a0e6-a1dc60fc67fe.png)

 ![Screen Shot 2021-07-24 at 21 10 39](https://user-images.githubusercontent.com/117249/126887483-d0ba0596-1335-4bfc-92ba-179e19917ef8.png) ![Screen Shot 2021-07-24 at 21 10 45](https://user-images.githubusercontent.com/117249/126887481-0c5e7954-9d46-4692-bc31-ce7b87713fce.png)

These should be relatively subtle changes.
