### PR TITLE
Allow users to provide a custom background

### DIFF
--- a/web-app/src/utils/setBodyImage.js
+++ b/web-app/src/utils/setBodyImage.js
@@ -2,5 +2,13 @@ export default function setBodyImage() {
     const body = document.body;
     const settings = JSON.parse(window.sessionStorage.getItem("settings"));
 
-    body.style.backgroundImage = 'url("/backgrounds/'+ (settings ? settings.gamebg : "Thousand_Eyes_Goats.png") +'")';
+    let url;
+    if (!settings) {
+        url = '/backgrounds/Default.png';
+    } else if (settings.gamebg.startsWith('http')) {
+        url = settings.gamebg;
+    } else {
+        url =`/backgrounds/${settings.gamebg}`;
+    }
+    body.style.backgroundImage = `url("${url}")`;
 }

--- a/web-app/src/views/SettingsPage/SettingsPage.js
+++ b/web-app/src/views/SettingsPage/SettingsPage.js
@@ -48,6 +48,9 @@ const sleeveChoices = [
    "Underwater_Nun.png"
 ];
 
+
+const IMG_URL = /^https?:\/\/.*\.(Pp][Nn][Gg]|[Jj][Pp][Ee]?[Gg])$/;
+
 class SettingsPage extends PureComponent {
    constructor(props) {
       super(props);
@@ -69,6 +72,13 @@ class SettingsPage extends PureComponent {
       window.sessionStorage.setItem("settings", JSON.stringify(settings));
       this.setState({ settings, unsaved: true });
       setBodyImage();
+   };
+
+   setBgUrl = (event) => {
+      const url = event.target.value;
+      if (IMG_URL.test(url)) {
+         this.setBg(url);
+      }
    };
 
    setSleeves = (sleeves) => {
@@ -142,9 +152,21 @@ class SettingsPage extends PureComponent {
                <GridItem xs={12}>
                   <div className={classes.center}>
                      <CustomDropdown
-                        buttonText={"Game Background: " + formatFileName(gamebg)}
+                        buttonText={`Game Background: ${gamebg.startsWith("http") ? "Custom" : formatFileName(gamebg)}`}
                         buttonProps={{ color: "transparent" }}
                         dropdownList={[...backgrounds.map((bg) => <div onClick={() => this.setBg(bg)}>{formatFileName(bg)}</div>)]}
+                     />
+                     <CustomInput
+                           labelText="Custom Background URL"
+                           id="bgUrl"
+                           white
+                           labelProps={{style: {left: "0.9em"}}}
+                           formControlProps={{style: {width: "50%"}}}
+                           inputProps={{
+                              type: "text",
+                              defaultValue: gamebg.startsWith("http") ? gamebg : "",
+                              onChange: this.setBgUrl,
+                           }}
                      />
                   </div>
                </GridItem>


### PR DESCRIPTION
Possibly could use more polish but that can probably be addressed when we switch the background/sleeve selector to a carousel in #185.  I would imagine the background carousel could have a blank space with a big "+" icon that could then bring up the textbox to enter a URL for the new background.

<img width="1437" alt="Screen Shot 2021-07-26 at 15 42 30" src="https://user-images.githubusercontent.com/117249/127068481-83254026-7c56-43cb-b879-5772f49f8cce.png">
<img width="1438" alt="Screen Shot 2021-07-26 at 15 42 47" src="https://user-images.githubusercontent.com/117249/127068485-a6ac2d1a-4437-48ff-acae-4e06422f9f07.png">
