### PR TITLE
Subtly tweak expanded card spacing and support bullets

### DIFF
--- a/web-app/src/components/YugiohCardExpanded/EffectTooltips.js
+++ b/web-app/src/components/YugiohCardExpanded/EffectTooltips.js
@@ -10,6 +10,9 @@ class EffectTooltips extends PureComponent {
    render() {
       const { text, classes } = this.props;
 
+      // NOTE: safe given we control all the card text as it comes from cardDB.js
+      const br = s => <span dangerouslySetInnerHTML={{__html: s.replace(/●/g, '<br />●')}}></span>;
+
       let rtn = [];
       let remainingText = text;
 
@@ -18,7 +21,7 @@ class EffectTooltips extends PureComponent {
          const splitString = remainingText.split("<effect=");
          const firstPart = splitString.shift();
          splitString.join("<effect=");
-         if (firstPart) rtn.push(<Fragment key={id++}>{firstPart}</Fragment>);
+         if (firstPart) rtn.push(<Fragment key={id++}>{br(firstPart)}</Fragment>);
 
          const secondSplit = splitString.join("<effect=").split("</effect>");
          const secondPart = secondSplit.shift();
@@ -28,13 +31,13 @@ class EffectTooltips extends PureComponent {
          if (effectText)
             rtn.push(
                <Tooltip title={effectType + " Effect"} classes={{ tooltip: classes.tooltip }} key={id++}>
-                  <span className={classes.underhover}>{effectText}</span>
+                  <span className={classes.underhover}>{br(effectText)}</span>
                </Tooltip>
             );
          remainingText = thirdPart;
       }
 
-      if (remainingText) rtn.push(<Fragment key={id++}>{remainingText}</Fragment>);
+      if (remainingText) rtn.push(<Fragment key={id++}>{br(remainingText)}</Fragment>);
       return rtn;
    }
 }

--- a/web-app/src/components/YugiohCardExpanded/YugiohCardExpanded.js
+++ b/web-app/src/components/YugiohCardExpanded/YugiohCardExpanded.js
@@ -51,11 +51,9 @@ class YugiohCardExpanded extends PureComponent {
                   </div>
                )}
                <div className={classes.cardText}>
-                  <strong>{cardName}</strong> [{attribute || cardType}/{levelOrSubtype}]
-                  <br />
-                  <EffectTooltips text={text} />
-                  <br />
-                  {attribute && "ATK " + atk + " / DEF " + def}
+                  <div><strong>{cardName}</strong> [{attribute || cardType}/{levelOrSubtype}]</div>
+                  <div style={{margin: "2px 0", lineHeight: "1.3em"}}><EffectTooltips text={text} /></div>
+                  <div>{attribute && `ATK ${atk} / DEF ${def}`}</div>
                </div>
             </div>
          </div>


### PR DESCRIPTION
**Before** -> **After**
![Screen Shot 2021-07-26 at 17 20 28](https://user-images.githubusercontent.com/117249/127075572-8aeb3e78-fc90-494a-9dc3-6d4f9410f2f3.png) ![Screen Shot 2021-07-26 at 17 19 53](https://user-images.githubusercontent.com/117249/127075576-ec1495e6-ae7e-4267-a8c4-bc6ecf6c1aeb.png)

**TESTED** = checked all cards in the starter deck and tried various window sizes
