### PR TITLE
Decouple internal vs. external naming and improving variable naming consistency

### DIFF
--- a/Lambda/GameSocket/Mill.js
+++ b/Lambda/GameSocket/Mill.js
@@ -1,15 +1,16 @@
 const actionAndMessage = require("./utils/actionAndMessage.js");
+const display = require("./utils/display");
 
-// @action NewPhase
-// @desc Sends a payload to others when the turn is set
+// @action Mill
+// @desc Sends a payload to others about a card being milled
 // @access Private
 // @db 1 read, 0 writes
 async function mill(id, username, deck, params, connectionId, api) {
-   const message = { author: "Server", content: username + " milled until a " + params + "." };
-   const action = { action: "Mill_Until", data: { player: username, deck, params } };
+   const message = { author: "Server", content: `${username} milled until a ${display(params)}.` };
+   const action = { action: "MILL", data: { player: username, deck, params } };
 
    await actionAndMessage(id, action, message, connectionId, api);
-   return { statusCode: 200, body: "Set turn sent" };
+   return { statusCode: 200, body: "Card milled" };
 }
 
 module.exports = mill;

--- a/Lambda/GameSocket/SendCardMove.js
+++ b/Lambda/GameSocket/SendCardMove.js
@@ -1,5 +1,6 @@
 const actionAndMessage = require("./utils/actionAndMessage.js");
 const { HAND, DECK, GRAVEYARD, BANISHED } = require("./utils/constants");
+const display = require("./utils/display");
 
 // @action SendCardMove
 // @desc Sends a card movement from one player to the other (and watchers)
@@ -7,21 +8,21 @@ const { HAND, DECK, GRAVEYARD, BANISHED } = require("./utils/constants");
 // @db 1 read, 0 writes
 async function sendCardMove(id, username, from, fromCard, to, settingTrap, msg, connectionId, api) {
    const player = to.player === username ? " their " : to.player + "'s ";
-   const cardName =
-      settingTrap || (from.row === DECK && to.row === HAND && from.zone === -1) || (fromCard.facedown && to.row !== GRAVEYARD && to.row !== BANISHED)
-         ? "a card "
-         : fromCard.name;
+   const unknown = settingTrap ||
+      (from.row === DECK && to.row === HAND && from.zone === -1) ||
+      (fromCard.facedown && to.row !== GRAVEYARD && to.row !== BANISHED);
+   const cardName = unknown ? "a card " : fromCard.name;
    const adverb = msg || "";
    const noMessage = (from.row === HAND && to.row === HAND) || (from.row === DECK && to.row === DECK);
 
    const message = !noMessage && {
       author: "Server",
-      content: username + " " + adverb + " moved " + cardName + " from their " + from.row + " zone to " + player + to.row + " zone."
+      content: `${username} ${adverb} moved ${cardName} from their ${display(from.row)} zone to ${player}${display(to.row)} zone.`
    };
    const action = { action: "MOVE_CARD", data: { from, to } };
 
    await actionAndMessage(id, action, message, connectionId, api);
-   return { statusCode: 200, body: "LP adjusted" };
+   return { statusCode: 200, body: "Card moved" };
 }
 
 module.exports = sendCardMove;

--- a/Lambda/GameSocket/utils/constants.js
+++ b/Lambda/GameSocket/utils/constants.js
@@ -1,7 +1,10 @@
+const MONSTER = "monster";
+const SPELL_TRAP = "spellTrap";
+const FIELD_SPELL = "fieldSpell";
 const HAND = "hand";
 const DECK = "deck";
+const EXTRA_DECK = "extraDeck";
 const GRAVEYARD = "graveyard";
 const BANISHED = "banished";
-const MONSTER = "monster";
 
-module.exports = { HAND, DECK, GRAVEYARD, BANISHED, MONSTER };
+module.exports = { MONSTER, SPELL_TRAP, FIELD_SPELL, HAND, DECK, EXTRA_DECK, GRAVEYARD, BANISHED };

--- a/Lambda/GameSocket/utils/display.js
+++ b/Lambda/GameSocket/utils/display.js
@@ -1,0 +1,17 @@
+const { MONSTER, SPELL_TRAP, FIELD_SPELL, HAND, DECK, EXTRA_DECK, GRAVEYARD, BANISHED } = require("./utils/constants");
+
+function display(rowOrZone) {
+  switch (rowOrZone) {
+    case MONSTER: return "monster";
+    case SPELL_TRAP: return "s/t";
+    case FIELD_SPELL: return "field spell";
+    case HAND: return "hand";
+    case DECK: return "deck";
+    case EXTRA_DECK: return "Fusion Deck";
+    case GRAVEYARD: return "graveyard";
+    case BANISHED: return "banished";
+    default: return rowOrZone;
+  }
+}
+
+module.exports = display;

--- a/Lambda/LeagueSocket/config/config.js
+++ b/Lambda/LeagueSocket/config/config.js
@@ -9,8 +9,8 @@ module.exports = {
       hand: [],
       skippedDraws: 0,
       handRevealed: false,
-      "s/t": [null, null, null, null, null],
-      "field spell": null,
+      spellTrap: [null, null, null, null, null],
+      fieldSpell: null,
       monster: [null, null, null, null, null]
    }
 };

--- a/web-app/src/assets/jss/material-kit-react/components/yugiohCardStyle.js
+++ b/web-app/src/assets/jss/material-kit-react/components/yugiohCardStyle.js
@@ -88,11 +88,11 @@ const cardStyle = {
    containerHand: {
       ...container
    },
-   containerMon: {
+   containerMonster: {
       ...container,
       borderColor: effectMonster
    },
-   containerST: {
+   containerSpellTrap: {
       ...container,
       borderColor: st
    },
@@ -109,12 +109,12 @@ const cardStyle = {
       top: "100%",
       transform: "translateY(-100%) rotate(180deg)"
    },
-   containerVillainMon: {
+   containerVillainMonster: {
       ...container,
       transform: "rotate(180deg)",
       borderColor: effectMonster
    },
-   containerVillainST: {
+   containerVillainSpellTrap: {
       ...container,
       transform: "rotate(180deg)",
       borderColor: st
@@ -128,11 +128,11 @@ const cardStyle = {
       ...container,
       transform: "rotate(90deg)"
    },
-   iconsMon: {
+   iconsMonster: {
       paddingTop: "3%",
       ...icons
    },
-   iconsST: {
+   iconsSpellTrap: {
       paddingTop: "14%",
       ...icons
    },

--- a/web-app/src/components/YugiohCard/CardArt.js
+++ b/web-app/src/components/YugiohCard/CardArt.js
@@ -41,7 +41,7 @@ class CardArt extends PureComponent {
             )}
             <div className={classes.lowerHalf}>
                <div
-                  className={classes["icons" + (isMonster ? "Mon" : "ST")]}
+                  className={classes["icons" + (isMonster ? "Monster" : "SpellTrap")]}
                   style={{
                      lineHeight: nameHeight + "px"
                   }}

--- a/web-app/src/components/YugiohCard/YugiohCard.js
+++ b/web-app/src/components/YugiohCard/YugiohCard.js
@@ -18,7 +18,7 @@ import {
    CARD_RATIO,
    FACEDOWN_CARD,
    MONSTER,
-   ST,
+   SPELL_TRAP,
    FIELD_SPELL,
    HAND,
    DECK,
@@ -84,8 +84,9 @@ function YugiohCard({ height, notFull, player, row, zone, cardName, modal, isHer
 
    const { cardType, attribute, levelOrSubtype, atk, def } = getCardDetails(name);
 
-   const type =
-      dynamicZones.includes(row) && row !== DECK ? (levelOrSubtype === FIELD_SPELL && FIELD_SPELL) || OFF_FIELD + (!isNaN(levelOrSubtype) ? MONSTER : ST) : row;
+   const type = dynamicZones.includes(row) && row !== DECK
+      ? (levelOrSubtype === FIELD_SPELL && FIELD_SPELL) || OFF_FIELD + (!isNaN(levelOrSubtype) ? MONSTER : SPELL_TRAP)
+      : row;
 
    const [{ isDragging }, drag] = useDrag({
       item: { type, player, row, zone, cardName },
@@ -99,8 +100,8 @@ function YugiohCard({ height, notFull, player, row, zone, cardName, modal, isHer
    const acceptables =
       (!isHero && !blank && inBattlePhase && [MONSTER]) ||
       (fieldZone && FIELD_SPELL) ||
-      (monsterZone && [MONSTER, ST, OFF_FIELD + MONSTER, EXTRA_DECK]) ||
-      (STzone && [MONSTER, ST, OFF_FIELD + ST]) ||
+      (monsterZone && [MONSTER, SPELL_TRAP, OFF_FIELD + MONSTER, EXTRA_DECK]) ||
+      (STzone && [MONSTER, SPELL_TRAP, OFF_FIELD + SPELL_TRAP]) ||
       allTypes;
 
    const [{ isOver, canDrop }, drop] = useDrop({

--- a/web-app/src/components/YugiohCard/YugiohCard.js
+++ b/web-app/src/components/YugiohCard/YugiohCard.js
@@ -44,7 +44,7 @@ function YugiohCard({ height, notFull, player, row, zone, cardName, modal, isHer
    const classes = useStyles();
    const dispatch = useDispatch();
    const socket = useContext(WebSocketContext);
-   const { discardZone, deckZone, isDeck, isExtraDeck, isDiscardZone, inHand, monsterZone, STzone, fieldZone } = getBools(row, zone);
+   const { discardZone, deckZone, isDeck, isExtraDeck, isDiscardZone, inHand, monsterZone, spellTrapZone, fieldZone } = getBools(row, zone);
 
    let { deckCount, card, counters, sleeves, selected, heroPlayer, heroSelected, villSelected, handRevealed, inBattlePhase } = useSelector((state) => {
       const sfPlayer = state.field[player];
@@ -101,7 +101,7 @@ function YugiohCard({ height, notFull, player, row, zone, cardName, modal, isHer
       (!isHero && !blank && inBattlePhase && [MONSTER]) ||
       (fieldZone && FIELD_SPELL) ||
       (monsterZone && [MONSTER, SPELL_TRAP, OFF_FIELD + MONSTER, EXTRA_DECK]) ||
-      (STzone && [MONSTER, SPELL_TRAP, OFF_FIELD + SPELL_TRAP]) ||
+      (spellTrapZone && [MONSTER, SPELL_TRAP, OFF_FIELD + SPELL_TRAP]) ||
       allTypes;
 
    const [{ isOver, canDrop }, drop] = useDrop({
@@ -146,13 +146,13 @@ function YugiohCard({ height, notFull, player, row, zone, cardName, modal, isHer
    return (
       <div
          ref={dragOrDrop}
-         className={classes["container" + (inDef ? "Def" : villExtension + (facedown && (STzone || fieldZone) ? "" : rowClass(row)))]}
+         className={classes["container" + (inDef ? "Def" : villExtension + (facedown && (spellTrapZone || fieldZone) ? "" : rowClass(row)))]}
          style={{
             width,
             height,
             marginLeft: margin,
             marginRight: margin,
-            opacity: (isDragging || blank) && !monsterZone && !STzone && !fieldZone && !isDiscardZone && !isDeck && 0,
+            opacity: (isDragging || blank) && !monsterZone && !spellTrapZone && !fieldZone && !isDiscardZone && !isDeck && 0,
             borderWidth: (blank || facedown || deckZone || isOver || heroSelected || villSelected || revealed || (!isHero && inHand)) && "3px",
             borderColor:
                (isOver && canDrop && OVER_COLOR) ||

--- a/web-app/src/components/YugiohCard/ZoneLabel.js
+++ b/web-app/src/components/YugiohCard/ZoneLabel.js
@@ -6,6 +6,7 @@ import { withStyles } from "@material-ui/core/styles";
 import cardStyle from "assets/jss/material-kit-react/components/yugiohCardStyle.js";
 
 import { DECK, EXTRA_DECK } from "utils/constants.js";
+import display from "utils/display.js";
 
 class ZoneLabel extends PureComponent {
    render() {
@@ -19,7 +20,7 @@ class ZoneLabel extends PureComponent {
                   className={classes["zoneLabel" + villExtension + (counters ? "Counters" : "")]}
                   style={{ fontSize: size, lineHeight: size }}
                >
-                  <div>{counters || zoneLabel}</div>
+                  <div>{counters || display(zoneLabel)}</div>
                   {(counters ? <img className={classes.counterImg} src="/battle/Counter.png" alt="Counter" /> : '')}
                </div>
             )}

--- a/web-app/src/components/YugiohCard/utils.js
+++ b/web-app/src/components/YugiohCard/utils.js
@@ -1,4 +1,4 @@
-import { MONSTER, ST, FIELD_SPELL, HAND, DECK, EXTRA_DECK, deckZones, discardZones } from "utils/constants.js";
+import { MONSTER, SPELL_TRAP, FIELD_SPELL, HAND, DECK, EXTRA_DECK, deckZones, discardZones } from "utils/constants.js";
 
 function getBools(row, zone) {
    const discardZone = discardZones.includes(row);
@@ -8,7 +8,7 @@ function getBools(row, zone) {
    const isDiscardZone = discardZone && zone === -1;
    const inHand = row === HAND;
    const monsterZone = row === MONSTER;
-   const STzone = row === ST;
+   const STzone = row === SPELL_TRAP;
    const fieldZone = row === FIELD_SPELL;
 
    return { discardZone, deckZone, isDeck, isExtraDeck, isDiscardZone, inHand, monsterZone, STzone, fieldZone };
@@ -20,7 +20,7 @@ function rowClass(row) {
          return "Hand";
       case MONSTER:
          return "Mon";
-      case ST:
+      case SPELL_TRAP:
          return "ST";
       case FIELD_SPELL:
          return "Field";

--- a/web-app/src/components/YugiohCard/utils.js
+++ b/web-app/src/components/YugiohCard/utils.js
@@ -8,10 +8,10 @@ function getBools(row, zone) {
    const isDiscardZone = discardZone && zone === -1;
    const inHand = row === HAND;
    const monsterZone = row === MONSTER;
-   const STzone = row === SPELL_TRAP;
+   const spellTrapZone = row === SPELL_TRAP;
    const fieldZone = row === FIELD_SPELL;
 
-   return { discardZone, deckZone, isDeck, isExtraDeck, isDiscardZone, inHand, monsterZone, STzone, fieldZone };
+   return { discardZone, deckZone, isDeck, isExtraDeck, isDiscardZone, inHand, monsterZone, spellTrapZone, fieldZone };
 }
 
 function rowClass(row) {
@@ -19,9 +19,9 @@ function rowClass(row) {
       case HAND:
          return "Hand";
       case MONSTER:
-         return "Mon";
+         return "Monster";
       case SPELL_TRAP:
-         return "ST";
+         return "SpellTrap";
       case FIELD_SPELL:
          return "Field";
       default:

--- a/web-app/src/components/YugiohCardExpanded/CardScript.js
+++ b/web-app/src/components/YugiohCardExpanded/CardScript.js
@@ -9,7 +9,7 @@ import { moveCard, createTokens } from "stateStore/actions/game/field.js";
 import { addMessage } from "stateStore/actions/game/chat.js";
 import { filterDeck, millUntil, banishAll } from "stateStore/actions/game/scripts.js";
 
-import { GRAVEYARD, HAND, ST, SEARCH_DECK, BANISH_ALL, MILL_UNTIL, TOKENS, RANDOM_DISCARD, FLIP_COINS } from "utils/constants";
+import { GRAVEYARD, HAND, SPELL_TRAP, SEARCH_DECK, BANISH_ALL, MILL_UNTIL, TOKENS, RANDOM_DISCARD, FLIP_COINS } from "utils/constants";
 
 class CardScript extends PureComponent {
    runScript = (name, params) => {
@@ -88,7 +88,7 @@ class CardScript extends PureComponent {
 function fieldContains(field, card) {
    switch (card) {
       case "Nobleman of Crossout":
-         for (const key in field) for (const zone of field[key][ST]) if (zone && !zone.facedown && zone.name === card) return true;
+         for (const key in field) for (const zone of field[key][SPELL_TRAP]) if (zone && !zone.facedown && zone.name === card) return true;
          return false;
       default:
          return false;

--- a/web-app/src/databases/cardDB.js
+++ b/web-app/src/databases/cardDB.js
@@ -3263,7 +3263,7 @@ const monsters = {
       atk: 200,
       def: 700,
       text: "Insect/Flip/Effect – <effect=Trigger>FLIP: Excavate cards from the top of your Deck until you excavate a Spell/Trap, then add that card to your hand, also send the remaining cards to the GY.</effect>",
-      script: "Mill_Until:s/t"
+      script: "Mill_Until:spellTrap"
    },
    "Abyss Soldier": {
       cardType: "effectMonster",

--- a/web-app/src/stateStore/actions/game/scripts.js
+++ b/web-app/src/stateStore/actions/game/scripts.js
@@ -3,7 +3,7 @@ import { moveCard, shuffleDeck } from "./field.js";
 
 import getCardDetails from "utils/getCardDetails.js";
 import getOtherPlayer from "utils/getOtherPlayer.js";
-import { ST, DECK, GRAVEYARD, BANISHED, MILL, SEND_ENTIRE_GAMESTATE } from "utils/constants.js";
+import { SPELL_TRAP, DECK, GRAVEYARD, BANISHED, MILL, SEND_ENTIRE_GAMESTATE } from "utils/constants.js";
 
 function filterDeck(player, params) {
    const [filter, autoClose] = params.split(";");
@@ -22,7 +22,7 @@ function millUntil(player, deck, params, socket = false) {
          const card = deck[i];
          const cardDetails = card && getCardDetails(card.name);
 
-         if (params === ST) {
+         if (params === SPELL_TRAP) {
             if (isNaN(cardDetails.atk)) stop = true;
          }
 

--- a/web-app/src/stateStore/reducers/game/field.js
+++ b/web-app/src/stateStore/reducers/game/field.js
@@ -6,7 +6,7 @@ import expandDeck from "utils/expandDeck.js";
 import {
    FUSION_MONSTER,
    MONSTER,
-   ST,
+   SPELL_TRAP,
    HAND,
    GRAVEYARD,
    BANISHED,
@@ -43,16 +43,16 @@ import {
 
 const blankField = {
    lifepoints: 8000,
-   deck: [],
-   graveyard: [],
-   banished: [],
+   [DECK]: [],
+   [GRAVEYARD]: [],
+   [BANISHED]: [],
    usedFusions: {},
-   hand: [],
+   [HAND]: [],
    skippedDraws: 0,
    handRevealed: false,
-   "s/t": [null, null, null, null, null],
-   "field spell": null,
-   monster: [null, null, null, null, null]
+   [MONSTER]: [null, null, null, null, null],
+   [SPELL_TRAP]: [null, null, null, null, null],
+   [FIELD_SPELL]: null,
 };
 
 const initialState = {};
@@ -83,7 +83,7 @@ export default function (state = initialState, action) {
          if (fromCard.notOwned && dynamicZones.includes(to.row) && from.player === to.player) to.player = getOtherPlayer(to.player, state);
          if (from.player !== to.player) fromCard.notOwned = !fromCard.notOwned;
 
-         if (!fromCard.name.includes("Token") || to.row === MONSTER || to.row === ST) {
+         if (!fromCard.name.includes("Token") || to.row === MONSTER || to.row === SPELL_TRAP) {
             if (toExtraZones.includes(to.row) && getCardDetails(fromCard.name).cardType === FUSION_MONSTER) state[to.player].usedFusions[fromCard.name] -= 1;
             else if (dynamicZones.includes(to.row)) state[to.player][to.row].push({ name: fromCard.name });
             else if (to.row === FIELD_SPELL) state[to.player][FIELD_SPELL] = { ...fromCard };
@@ -91,10 +91,10 @@ export default function (state = initialState, action) {
          }
 
          if (to.row === MONSTER && facedown) state[to.player][MONSTER][to.zone].inDef = true;
-         else if (to.row === ST && !facedown) {
-            const cardDetails = getCardDetails(state[to.player][ST][to.zone].name);
+         else if (to.row === SPELL_TRAP && !facedown) {
+            const cardDetails = getCardDetails(state[to.player][SPELL_TRAP][to.zone].name);
             if (cardDetails.cardType === TRAP) {
-               state[to.player][ST][to.zone].facedown = true;
+               state[to.player][SPELL_TRAP][to.zone].facedown = true;
                settingTrap = true;
             }
          }
@@ -103,8 +103,8 @@ export default function (state = initialState, action) {
             if (to.row === GRAVEYARD) playSound("/sounds/tograve.mp3");
             else if (to.row === BANISHED) playSound("/sounds/tobanished.mp3");
             else if (settingTrap || (facedown && from.row !== to.row && to.row !== HAND)) playSound("/sounds/set.mp3");
-            else if (to.row === MONSTER && from.row !== MONSTER && from.row !== ST) playSound("/sounds/summon.mp3");
-            else if (to.row === ST && from.row !== MONSTER && from.row !== ST) playSound("/sounds/activate.mp3");
+            else if (to.row === MONSTER && from.row !== MONSTER && from.row !== SPELL_TRAP) playSound("/sounds/summon.mp3");
+            else if (to.row === SPELL_TRAP && from.row !== MONSTER && from.row !== SPELL_TRAP) playSound("/sounds/activate.mp3");
             else if (drawingFromDeck) playSound("/sounds/drawcard.mp3");
             else if (to.row === HAND && from.row !== HAND) playSound("/sounds/tohand.mp3");
          }

--- a/web-app/src/utils/constants.js
+++ b/web-app/src/utils/constants.js
@@ -8,7 +8,6 @@ export const CARD_RATIO = 1.45;
 export const FACEDOWN_CARD = "Facedown Card";
 
 // cardTypes
-export const NORMAL_MONSTER = "normalMonster";
 export const EFFECT_MONSTER = "effectMonster";
 export const FUSION_MONSTER = "fusionMonster";
 export const SPELL = "Spell";
@@ -22,11 +21,11 @@ export const allLocations = [MAINDECK, SIDEDECK, SEARCH_RESULTS];
 
 // rows & zones
 export const MONSTER = "monster";
-export const ST = "s/t";
-export const FIELD_SPELL = "Field";
+export const SPELL_TRAP = "spellTrap";
+export const FIELD_SPELL = "fieldSpell";
 export const HAND = "hand";
 export const DECK = "deck";
-export const EXTRA_DECK = "Fusion Deck";
+export const EXTRA_DECK = "extraDeck";
 export const deckZones = [DECK, EXTRA_DECK];
 export const GRAVEYARD = "graveyard";
 export const BANISHED = "banished";
@@ -34,7 +33,7 @@ export const discardZones = [GRAVEYARD, BANISHED];
 export const dndZones = [DECK, ...discardZones];
 export const dynamicZones = [HAND, DECK, ...discardZones];
 export const toExtraZones = [HAND, ...deckZones];
-export const onField = [MONSTER, ST, FIELD_SPELL];
+export const onField = [MONSTER, SPELL_TRAP, FIELD_SPELL];
 
 // battle
 export const ATTACKING = "Attacking";
@@ -107,7 +106,7 @@ export const SEND_COUNTERS = "SendCounters";
 
 // ItemTypes
 export const OFF_FIELD = "offField";
-export const allTypes = [MONSTER, ST, FIELD_SPELL, OFF_FIELD + MONSTER, OFF_FIELD + ST, EXTRA_DECK, DECK];
+export const allTypes = [MONSTER, SPELL_TRAP, FIELD_SPELL, OFF_FIELD + MONSTER, OFF_FIELD + SPELL_TRAP, EXTRA_DECK, DECK];
 
 // colors
 export const OVER_COLOR = "#00FF00";

--- a/web-app/src/utils/constants.js
+++ b/web-app/src/utils/constants.js
@@ -21,8 +21,8 @@ export const allLocations = [MAINDECK, SIDEDECK, SEARCH_RESULTS];
 
 // rows & zones
 export const MONSTER = "monster";
-export const SPELL_TRAP = "spellTrap";
-export const FIELD_SPELL = "fieldSpell";
+export const SPELL_TRAP = "s/t";
+export const FIELD_SPELL = "field spell";
 export const HAND = "hand";
 export const DECK = "deck";
 export const EXTRA_DECK = "extraDeck";

--- a/web-app/src/utils/display.js
+++ b/web-app/src/utils/display.js
@@ -1,0 +1,17 @@
+const { MONSTER, SPELL_TRAP, FIELD_SPELL, HAND, DECK, EXTRA_DECK, GRAVEYARD, BANISHED } = require("utils/constants");
+
+function display(rowOrZone) {
+  switch (rowOrZone) {
+    case MONSTER: return "monster";
+    case SPELL_TRAP: return "s/t";
+    case FIELD_SPELL: return "field spell";
+    case HAND: return "hand";
+    case DECK: return "deck";
+    case EXTRA_DECK: return "Fusion Deck";
+    case GRAVEYARD: return "graveyard";
+    case BANISHED: return "banished";
+    default: return rowOrZone;
+  }
+}
+
+module.exports = display;

--- a/web-app/src/views/Game/Battlefield/Battlefield.js
+++ b/web-app/src/views/Game/Battlefield/Battlefield.js
@@ -9,7 +9,7 @@ import YugiohCard from "components/YugiohCard/YugiohCard.js";
 import Hand from "./Hand.js";
 import RightTools from "./RightTools/RightTools.js";
 
-import { MONSTER, ST, FIELD_SPELL, DECK, EXTRA_DECK, GRAVEYARD, BANISHED, VILLAIN_HAND_HEIGHT_FRACTION } from "utils/constants.js";
+import { MONSTER, SPELL_TRAP, FIELD_SPELL, DECK, EXTRA_DECK, GRAVEYARD, BANISHED, VILLAIN_HAND_HEIGHT_FRACTION } from "utils/constants.js";
 
 import { withStyles } from "@material-ui/core/styles";
 import styles from "assets/jss/material-kit-react/views/gameSections/battlefield.js";
@@ -39,10 +39,10 @@ class Battlefield extends Component {
                   ) : (
                      <Hand player={VILLAIN} handCount={handCounts[VILLAIN] || 0} rowHeight={rowHeight} isHero={false} />
                   )}
-                  <FieldRow rowHeight={rowHeight} cardHeight={cardHeight} player={VILLAIN} rowType={ST} divOnly={solo} />
+                  <FieldRow rowHeight={rowHeight} cardHeight={cardHeight} player={VILLAIN} rowType={SPELL_TRAP} divOnly={solo} />
                   <FieldRow rowHeight={rowHeight} cardHeight={cardHeight} player={VILLAIN} rowType={MONSTER} divOnly={solo} />
                   <FieldRow rowHeight={rowHeight} cardHeight={cardHeight} player={HERO} rowType={MONSTER} isHero />
-                  <FieldRow rowHeight={rowHeight} cardHeight={cardHeight} player={HERO} rowType={ST} isHero />
+                  <FieldRow rowHeight={rowHeight} cardHeight={cardHeight} player={HERO} rowType={SPELL_TRAP} isHero />
                   <Hand player={HERO} handCount={handCounts[HERO] || 0} rowHeight={rowHeight} isHero={true} />
                </div>
                <div className={classes.cardColumn}>


### PR DESCRIPTION
- make all the field names on state follow a consistent camelCase schema\*
- use a separate `display` function to enable us to display pretty strings to humans (a followup PR will Konami-fy this mapping and all the messages)
- fix `Mill`'s action name and minor copy+paste discrepancies in the lambda functions touched by this commit

\* **This is a breaking change - this PR contains no migration logic so existing state representations will break**
