### PR TITLE
Fix minor nits

### DIFF
--- a/Lambda/GameSocket/SendCardMove.js
+++ b/Lambda/GameSocket/SendCardMove.js
@@ -13,7 +13,7 @@ async function sendCardMove(id, username, from, fromCard, to, settingTrap, msg, 
    const unknown =
       settingTrap || (from.row === DECK && to.row === HAND && from.zone === -1) || (fromCard.facedown && to.row !== GRAVEYARD && to.row !== BANISHED);
    const cardName = unknown ? "a card " : "<<" + fromCard.name + ">>";
-   const adverb = msg || "";
+   const adverb = ` ${msg} ` || " ";
    const noMessage = (from.row === HAND && to.row === HAND) || (from.row === DECK && to.row === DECK);
 
    const fromZone = ZONES.includes(from.row) ? `${display(from.row)} Zone` : display(from.row);
@@ -21,7 +21,7 @@ async function sendCardMove(id, username, from, fromCard, to, settingTrap, msg, 
 
    const message = !noMessage && {
       author: "Server",
-      content: `${username} ${adverb} moved ${cardName} from their ${fromZone} to ${player} ${toZone}.`
+      content: `${username}${adverb}moved ${cardName} from their ${fromZone} to ${player} ${toZone}.`
    };
    const action = { action: "MOVE_CARD", data: { from, to } };
 

--- a/Lambda/GameSocket/SendDnd.js
+++ b/Lambda/GameSocket/SendDnd.js
@@ -4,7 +4,7 @@ const actionAndMessage = require("./utils/actionAndMessage.js");
 // @desc Sends a draw and discard effect from one player to the oher (and watchers)
 // @access Private
 // @db 1 read, 0 writes
-async function sendAttack(id, username, count, connectionId, api) {
+async function SendDnd(id, username, count, connectionId, api) {
    const message = { author: "Server", content: username + " discarded their hand" + (count > 0 ? " and drew " + count + " cards." : ".") };
    const action = { action: "DISCARD_AND_DRAW", data: { player: username, count } };
 
@@ -12,4 +12,4 @@ async function sendAttack(id, username, count, connectionId, api) {
    return { statusCode: 200, body: "Discard and draw" };
 }
 
-module.exports = sendAttack;
+module.exports = SendDnd;

--- a/Lambda/UsersEndpoint/deck/get.js
+++ b/Lambda/UsersEndpoint/deck/get.js
@@ -4,7 +4,7 @@ const findUser = require("../utils/findUser.js");
 // @desc Gets a deck it is is public
 // @access Public
 // @db 1 reads, 0 write
-async function save(body) {
+async function getDeck(body) {
    const { username, deckName } = body;
 
    const user = await findUser(username, "decks");
@@ -14,4 +14,4 @@ async function save(body) {
    else return { statusCode: 200, body: { deck } };
 }
 
-module.exports = save;
+module.exports = getDeck;


### PR DESCRIPTION
I don't think the `adverb` revert was actually a typo, but with the approach at HEAD you will get a double space if theres no `msg`. Technically this doesn't matter as HTML will collapse consecutive whitespace, but its strictly incorrect if the string ends up being displayed in other contexts.