### PR TITLE
Add ids to card DB for import/export functionality

### DIFF
--- a/web-app/src/databases/cardDB/monsters/effectMonsters.js
+++ b/web-app/src/databases/cardDB/monsters/effectMonsters.js
@@ -21,6 +21,7 @@ import {
 
 const effectMonsters = {
    "Ryu Kokki": {
+      id: "57281778",
       cardType: EFFECT_MONSTER,
       attribute: DARK,
       levelOrSubtype: 6,
@@ -29,6 +30,7 @@ const effectMonsters = {
       text: "Zombie/Effect – <effect=Trigger>At the end of the Damage Step, if this card battled a Warrior or Spellcaster monster: Destroy that monster.</effect>"
    },
    "Ryu-Kishin Clown": {
+      id: "42647539",
       cardType: EFFECT_MONSTER,
       attribute: DARK,
       levelOrSubtype: 2,
@@ -37,6 +39,7 @@ const effectMonsters = {
       text: "Fiend/Effect – <effect=Trigger>When this card is Summoned: Target 1 face-up monster on the field; change its battle position.</effect>"
    },
    "Sasuke Samurai": {
+      id: "16222645",
       cardType: EFFECT_MONSTER,
       attribute: WIND,
       levelOrSubtype: 2,
@@ -45,6 +48,7 @@ const effectMonsters = {
       text: "Warrior/Effect – <effect=Trigger>At the start of the Damage Step, if this card attacks a face-down Defense Position monster: Destroy that face-down monster.</effect>"
    },
    "Sasuke Samurai #3": {
+      id: "77379481",
       cardType: EFFECT_MONSTER,
       attribute: LIGHT,
       levelOrSubtype: 3,
@@ -53,6 +57,7 @@ const effectMonsters = {
       text: "Warrior/Effect – <effect=Trigger>When this card inflicts Battle Damage to your opponent: Your opponent draws cards until their hand has 7 cards.</effect>"
    },
    "Servant of Catabolism": {
+      id: "02792265",
       cardType: EFFECT_MONSTER,
       attribute: LIGHT,
       levelOrSubtype: 3,
@@ -61,6 +66,7 @@ const effectMonsters = {
       text: "Aqua/Effect – <effect=Continuous>This card can attack directly.</effect>"
    },
    Shadowslayer: {
+      id: "20939559",
       cardType: EFFECT_MONSTER,
       attribute: DARK,
       levelOrSubtype: 4,
@@ -69,6 +75,7 @@ const effectMonsters = {
       text: "Fiend/Effect – <effect=Continuous>If all monsters your opponent controls are in Defense Position, this card can attack directly.</effect>"
    },
    "Skull-Mark Ladybug": {
+      id: "64306248",
       cardType: EFFECT_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 4,
@@ -78,6 +85,7 @@ const effectMonsters = {
       prepopLP: { hero: 1000 }
    },
    "Slate Warrior": {
+      id: "78636495",
       cardType: EFFECT_MONSTER,
       attribute: WIND,
       levelOrSubtype: 4,
@@ -86,6 +94,7 @@ const effectMonsters = {
       text: "Fiend/Flip/Effect – <effect=Trigger>FLIP: This card gains 500 ATK/DEF.</effect> <effect=Trigger>If this card is destroyed by battle: The monster that destroyed it loses 500 ATK/DEF</effect>"
    },
    "Spirit Caller": {
+      id: "48659020",
       cardType: EFFECT_MONSTER,
       attribute: LIGHT,
       levelOrSubtype: 3,
@@ -94,6 +103,7 @@ const effectMonsters = {
       text: "Spellcaster/Flip/Effect – <effect=Trigger>FLIP: You can target 1 Level 3 or lower Normal Monster in your Graveyard; Special Summon that target.</effect>"
    },
    "Sonic Jammer": {
+      id: "84550200",
       cardType: EFFECT_MONSTER,
       attribute: WIND,
       levelOrSubtype: 2,
@@ -102,6 +112,7 @@ const effectMonsters = {
       text: "Machine/Flip/Effect – <effect=Trigger>FLIP: Your opponent cannot activate any Spells until the end of the next turn.</effect>"
    },
    "Spirit of the Breeze": {
+      id: "53530069",
       cardType: EFFECT_MONSTER,
       attribute: WIND,
       levelOrSubtype: 3,
@@ -111,6 +122,7 @@ const effectMonsters = {
       prepopLP: { hero: 1000 }
    },
    "Star Boy": {
+      id: "08201910",
       cardType: EFFECT_MONSTER,
       attribute: WATER,
       levelOrSubtype: 2,
@@ -119,6 +131,7 @@ const effectMonsters = {
       text: "Aqua/Effect – <effect=Continuous>All WATER monsters gain 500 ATK and all FIRE monsters lose 400 ATK.</effect>"
    },
    "Stealth Bird": {
+      id: "03510565",
       cardType: EFFECT_MONSTER,
       attribute: DARK,
       levelOrSubtype: 3,
@@ -127,6 +140,7 @@ const effectMonsters = {
       text: "Winged Beast/Effect – <effect=Ignition>Once per turn: You can change this card to face-down Defense Position.</effect> <effect=Trigger>When this card is Flip Summoned: Inflict 1000 damage to your opponent.</effect>"
    },
    "Stone Statue of the Aztecs": {
+      id: "31812496",
       cardType: EFFECT_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 4,
@@ -135,6 +149,7 @@ const effectMonsters = {
       text: "Rock/Effect – <effect=Continuous>Double any Battle Damage your opponent takes when they attack this monster.</effect>"
    },
    Supply: {
+      id: "44072894",
       cardType: EFFECT_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 4,
@@ -143,6 +158,7 @@ const effectMonsters = {
       text: "Warrior/Flip/Effect – <effect=Trigger>FLIP: Target 2 monsters in your Graveyard that were sent there for a Fusion Summon; return those targets to your hand.</effect>"
    },
    "Susa Soldier": {
+      id: "40473581",
       cardType: EFFECT_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 4,
@@ -151,6 +167,7 @@ const effectMonsters = {
       text: "Thunder/Spirit/Effect – <effect=Summon>Cannot be Special Summoned.</effect> <effect=Continuous>Battle Damage this card inflicts to your opponent is halved.</effect> <effect=Trigger>Once per turn, during the End Phase, if this card was Normal Summoned or flipped face-up this turn: Return it to the hand.</effect>"
    },
    "Swamp Battleguard": {
+      id: "40453765",
       cardType: EFFECT_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 5,
@@ -159,6 +176,7 @@ const effectMonsters = {
       text: 'Warrior/Effect – <effect=Continuous>Gains 500 ATK for each "Lava Battleguard" you control.</effect>'
    },
    "Swift Gaia the Fierce Knight": {
+      id: "16589042",
       cardType: EFFECT_MONSTER,
       attribute: DARK,
       levelOrSubtype: 7,
@@ -167,6 +185,7 @@ const effectMonsters = {
       text: "Warrior/Effect – <effect=Summon>If this is the only card in your hand, you can Normal Summon it without Tributing.</effect>"
    },
    "Tactical Espionage Expert": {
+      id: "89698120",
       cardType: EFFECT_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 3,
@@ -175,6 +194,7 @@ const effectMonsters = {
       text: "Warrior/Effect – <effect=Continuous>When Normal Summoned, Traps cannot be activated.</effect>"
    },
    Teva: {
+      id: "16469012",
       cardType: EFFECT_MONSTER,
       attribute: LIGHT,
       levelOrSubtype: 5,
@@ -183,6 +203,7 @@ const effectMonsters = {
       text: "Warrior/Effect – <effect=Trigger>When this card is Tribute Summoned: Your opponent cannot declare an attack during their next turn.</effect>"
    },
    "The Agent of Wisdom - Mercury": {
+      id: "38730226",
       cardType: EFFECT_MONSTER,
       attribute: LIGHT,
       levelOrSubtype: 4,
@@ -191,6 +212,7 @@ const effectMonsters = {
       text: "Fairy/Effect – <effect=Trigger>During your Standby Phase, if you controlled this face-up card and had no cards in your hand at the end of the opponent's last End Phase: Draw 1 card.</effect>"
    },
    "The Bistro Butcher": {
+      id: "71107816",
       cardType: EFFECT_MONSTER,
       attribute: DARK,
       levelOrSubtype: 4,
@@ -199,6 +221,7 @@ const effectMonsters = {
       text: "Fiend/Effect – <effect=Trigger>When this card inflicts Battle Damage to your opponent: Your opponent draws 2 cards.</effect>"
    },
    "The Fiend Megacyber": {
+      id: "66362965",
       cardType: EFFECT_MONSTER,
       attribute: DARK,
       levelOrSubtype: 6,
@@ -207,6 +230,7 @@ const effectMonsters = {
       text: "Warrior/Effect – <effect=Summon>If your opponent controls at least 2 more monsters than you do, you can Special Summon this card (from your hand).</effect>"
    },
    "The Hunter with 7 Weapons": {
+      id: "01525329",
       cardType: EFFECT_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 3,
@@ -215,6 +239,7 @@ const effectMonsters = {
       text: "Warrior/Effect – <effect=Trigger>When this card is Normal Summoned: Declare 1 Type.</effect> <effect=Trigger>When this card battles a monster of that Type: This card gains 1000 ATK during Damage Calculation only.</effect>"
    },
    "The Immortal of Thunder": {
+      id: "84926738",
       cardType: EFFECT_MONSTER,
       attribute: LIGHT,
       levelOrSubtype: 4,
@@ -224,6 +249,7 @@ const effectMonsters = {
       prepopLP: { hero: 3000 }
    },
    "The Kick Man": {
+      id: "90407382",
       cardType: EFFECT_MONSTER,
       attribute: DARK,
       levelOrSubtype: 3,
@@ -232,6 +258,7 @@ const effectMonsters = {
       text: "Zombie/Effect – <effect=Trigger>When this card is Special Summoned: You can target 1 legal Equip Spell in your Graveyard; equip it to this card.</effect>"
    },
    "The Legendary Fisherman": {
+      id: "03643300",
       cardType: EFFECT_MONSTER,
       attribute: WATER,
       levelOrSubtype: 5,
@@ -240,6 +267,7 @@ const effectMonsters = {
       text: 'Warrior/Effect – <effect=Continuous>While "Umi" is on the field, this card is unaffected by Spell effects and cannot be targeted for attacks, but does not prevent your opponent from attacking you directly.</effect>'
    },
    "The Thing in the Crater": {
+      id: "78243409",
       cardType: EFFECT_MONSTER,
       attribute: FIRE,
       levelOrSubtype: 4,
@@ -248,6 +276,7 @@ const effectMonsters = {
       text: "Pyro/Effect – <effect=Trigger>When this card is destroyed and sent to the Graveyard: You can Special Summon 1 Pyro monster from your hand.</effect>"
    },
    "The Unhappy Maiden": {
+      id: "51275027",
       cardType: EFFECT_MONSTER,
       attribute: LIGHT,
       levelOrSubtype: 1,
@@ -256,6 +285,7 @@ const effectMonsters = {
       text: "Spellcaster/Effect – <effect=Trigger>When this card is destroyed by battle and sent to the Graveyard: End the Battle Phase.</effect>"
    },
    "The Wicked Worm Beast": {
+      id: "06285791",
       cardType: EFFECT_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 3,
@@ -264,6 +294,7 @@ const effectMonsters = {
       text: "Beast/Effect – <effect=Trigger>Once per turn, during your End Phase: Return this face-up card you control to the hand.</effect>"
    },
    "Thousand Needles": {
+      id: "33977496",
       cardType: EFFECT_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 4,
@@ -272,6 +303,7 @@ const effectMonsters = {
       text: "Beast/Effect – <effect=Trigger>When this Defense Position card is attacked by a monster with lower ATK than this card's DEF: Destroy that monster at the end of the Damage Step.</effect>"
    },
    "Thunder Nyan Nyan": {
+      id: "70797118",
       cardType: EFFECT_MONSTER,
       attribute: LIGHT,
       levelOrSubtype: 4,
@@ -280,6 +312,7 @@ const effectMonsters = {
       text: "Thunder/Effect – <effect=Continuous>If you control a non-LIGHT monster, destroy this card.</effect>"
    },
    "Twin-Headed Wolf": {
+      id: "88132637",
       cardType: EFFECT_MONSTER,
       attribute: DARK,
       levelOrSubtype: 4,
@@ -288,6 +321,7 @@ const effectMonsters = {
       text: "Fiend/Effect – <effect=Continuous>If you control another Fiend, negate the effects of Flip monsters destroyed by battle with this card.</effect>"
    },
    "Twinheaded Beast": {
+      id: "82035781",
       cardType: EFFECT_MONSTER,
       attribute: FIRE,
       levelOrSubtype: 6,
@@ -296,6 +330,7 @@ const effectMonsters = {
       text: "Beast/Effect – <effect=Continuous>This card can make a second attack during each Battle Phase.</effect>"
    },
    "Two Thousand Needles": {
+      id: "83228073",
       cardType: EFFECT_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 5,
@@ -304,6 +339,7 @@ const effectMonsters = {
       text: "Beast/Effect – <effect=Trigger>When this Defense Position card is attacked by a monster with lower ATK than this card's DEF: Destroy that monster at the end of the Damage Step.</effect>"
    },
    "Ultimate Obedient Fiend": {
+      id: "32240937",
       cardType: EFFECT_MONSTER,
       attribute: FIRE,
       levelOrSubtype: 10,
@@ -312,6 +348,7 @@ const effectMonsters = {
       text: "Fiend/Effect – <effect=Continuous>Cannot attack unless you control no other cards and you have no cards in your hand.</effect> <effect=Continuous>Negate the effects of monsters destroyed by battle with this card.</effect>"
    },
    "Vampire Baby": {
+      id: "56387350",
       cardType: EFFECT_MONSTER,
       attribute: DARK,
       levelOrSubtype: 3,
@@ -320,6 +357,7 @@ const effectMonsters = {
       text: "Zombie/Effect – <effect=Trigger>At the end of the Battle Phase, if this card destroyed a monster by battle and sent it to the Graveyard this turn: You can Special Summon that monster to your side of the field.</effect>"
    },
    "White Magician Pikeru": {
+      id: "81383947",
       cardType: EFFECT_MONSTER,
       attribute: LIGHT,
       levelOrSubtype: 2,
@@ -328,6 +366,7 @@ const effectMonsters = {
       text: "Spellcaster/Effect – <effect=Trigger>Once per turn, during your Standby Phase: Gain 400 Life Points for each monster you control.</effect>"
    },
    "Witch's Apprentice": {
+      id: "80741828",
       cardType: EFFECT_MONSTER,
       attribute: DARK,
       levelOrSubtype: 2,
@@ -336,6 +375,7 @@ const effectMonsters = {
       text: "Spellcaster/Effect – <effect=Continuous>All DARK monsters gain 500 ATK and all LIGHT monsters lose 400 ATK.</effect>"
    },
    "3-Hump Lacooda": {
+      id: "86988864",
       cardType: EFFECT_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 3,
@@ -344,6 +384,7 @@ const effectMonsters = {
       text: 'Beast/Effect – <effect=Ignition>If you control 3 "3-Hump Lacooda": You can Tribute 2 of them; draw 3 cards.</effect>'
    },
    "8-Claws Scorpion": {
+      id: "14261867",
       cardType: EFFECT_MONSTER,
       attribute: DARK,
       levelOrSubtype: 2,
@@ -352,6 +393,7 @@ const effectMonsters = {
       text: "Insect/Effect – <effect=Ignition>Once per turn: You can change this card to face-down Defense Position.</effect> <effect=Trigger>When this card attacks an opponent's face-down Defense Position monster, during damage calculation: This card's ATK becomes 2400 during that damage calculation only.</effect>"
    },
    "Absorbing Kid from the Sky": {
+      id: "49771608",
       cardType: EFFECT_MONSTER,
       attribute: LIGHT,
       levelOrSubtype: 4,
@@ -360,6 +402,7 @@ const effectMonsters = {
       text: "Fairy/Effect – <effect=Trigger>When this card destroys a monster by battle and sends it to the Graveyard: Gain Life Points equal to that monster's original Level x300.</effect>"
    },
    "Amazoness Fighter": {
+      id: "55821894",
       cardType: EFFECT_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 4,
@@ -368,6 +411,7 @@ const effectMonsters = {
       text: "Warrior/Effect – <effect=Continuous>You take no battle damage from attacks involving this card.</effect>"
    },
    "Amazoness Paladin": {
+      id: "47480070",
       cardType: EFFECT_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 4,
@@ -376,6 +420,7 @@ const effectMonsters = {
       text: 'Warrior/Effect – <effect=Continuous>This card gains 100 ATK for each "Amazoness" monster you control.</effect>'
    },
    "Amazoness Tiger": {
+      id: "10979723",
       cardType: EFFECT_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 4,
@@ -384,6 +429,7 @@ const effectMonsters = {
       text: 'Beast/Effect – <effect=Continuous>You can only control 1 "Amazoness Tiger".</effect> <effect=Continuous> This card gains 400 ATK for each "Amazoness" monster you control.</effect> <effect=Continuous>Your opponent cannot attack any face-up "Amazoness" monsters, except this one.</effect>'
    },
    "Arcane Archer of the Forest": {
+      id: "55001420",
       cardType: EFFECT_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 3,
@@ -392,6 +438,7 @@ const effectMonsters = {
       text: "Warrior/Effect – <effect=Continuous>If you control a Plant monster, this card cannot be attacked.</effect> <effect=Ignition>You can Tribute 1 Plant monster, then target 1 Spell/Trap on the field; destroy that target.</effect>"
    },
    "Archfiend of Gilfer": {
+      id: "50287060",
       cardType: EFFECT_MONSTER,
       attribute: DARK,
       levelOrSubtype: 6,
@@ -400,6 +447,7 @@ const effectMonsters = {
       text: "Fiend/Effect – <effect=Trigger>When this card is sent to the Graveyard: You can target 1 face-up monster on the field; equip that target with this card.</effect> <effect=Continuous-like>That monster loses 500 ATK while equipped with this card.</effect>"
    },
    "Armed Samurai - Ben Kei": {
+      id: "84430950",
       cardType: EFFECT_MONSTER,
       attribute: DARK,
       levelOrSubtype: 4,
@@ -408,6 +456,7 @@ const effectMonsters = {
       text: "Warrior/Effect – <effect=Continuous>For each Equip Card equipped to this card, it gains 1 additional attack during each Battle Phase.</effect>"
    },
    "Aswan Apparition": {
+      id: "88236094",
       cardType: EFFECT_MONSTER,
       attribute: DARK,
       levelOrSubtype: 3,
@@ -416,6 +465,7 @@ const effectMonsters = {
       text: "Fiend/Effect – <effect=Trigger>If this card inflicts Battle Damage to your opponent: You can target 1 Trap in your Graveyard; place it on top of your Deck.</effect>"
    },
    "Atomic Firefly": {
+      id: "87340664",
       cardType: EFFECT_MONSTER,
       attribute: LIGHT,
       levelOrSubtype: 1,
@@ -424,6 +474,7 @@ const effectMonsters = {
       text: "Insect/Effect – <effect=Trigger>If this card is destroyed by battle, and was face-up at the start of the Damage Step: The player who destroyed it takes 1000 damage.</effect>"
    },
    "Avatar of The Pot": {
+      id: "99284890",
       cardType: EFFECT_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 3,
@@ -432,6 +483,7 @@ const effectMonsters = {
       text: 'Rock/Effect – <effect=Ignition>Send 1 "Pot of Greed" from your hand to the Graveyard; draw 3 cards.</effect>'
    },
    "Balloon Lizard": {
+      id: "39892082",
       cardType: EFFECT_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 4,
@@ -440,6 +492,7 @@ const effectMonsters = {
       text: "Reptile/Effect – <effect=Trigger>Once per turn, during your Standby Phase: Place 1 counter on this card.</effect> <effect=Trigger>When this card is destroyed: Your opponent takes 400 damage for each of the counters that were on it.</effect>"
    },
    "Batteryman AA": {
+      id: "63142001",
       cardType: EFFECT_MONSTER,
       attribute: LIGHT,
       levelOrSubtype: 3,
@@ -448,6 +501,7 @@ const effectMonsters = {
       text: 'Thunder/Effect – <effect=Continuous>If all "Batteryman AA"(s) you control are in Attack Position, this card gains 1000 ATK for each.</effect> <effect=Continuous>If all "Batteryman AA"(s) you control are in Defense Position, this card gains 1000 DEF for each.</effect>'
    },
    "Berserk Dragon": {
+      id: "85605684",
       cardType: EFFECT_MONSTER,
       attribute: DARK,
       levelOrSubtype: 8,
@@ -456,6 +510,7 @@ const effectMonsters = {
       text: 'Zombie/Effect – <effect=Summon>Cannot be Normal Summoned/Set.</effect> <effect=Summon>Must be Special Summoned with "A Deal with Dark Ruler" and cannot be Special Summoned by other ways.</effect> <effect=Continuous>This card can attack all monsters your opponent controls once each.</effect> <effect=Continuous>During each of your End Phases, this card loses 500 ATK.</effect>'
    },
    "Blade Rabbit": {
+      id: "58268433",
       cardType: EFFECT_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 2,
@@ -464,6 +519,7 @@ const effectMonsters = {
       text: "Beast/Effect – <effect=Trigger>When this card is changed from Attack Position to face-up Defense Position: Target 1 monster your opponent controls; destroy that target.</effect>"
    },
    "Blindly Loyal Goblin": {
+      id: "35215622",
       cardType: EFFECT_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 4,
@@ -472,6 +528,7 @@ const effectMonsters = {
       text: "Warrior/Effect – <effect=Continuous>Control of this face-up card cannot switch.</effect>"
    },
    "Boar Soldier": {
+      id: "21340051",
       cardType: EFFECT_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 4,
@@ -480,6 +537,7 @@ const effectMonsters = {
       text: "Beast-Warrior/Effect – <effect=Trigger>If this card is Normal Summoned: Destroy this card.</effect> <effect=Continuous>If your opponent controls a monster(s), this card loses 1000 ATK.</effect>"
    },
    "Burning Algae": {
+      id: "41859700",
       cardType: EFFECT_MONSTER,
       attribute: FIRE,
       levelOrSubtype: 3,
@@ -488,6 +546,7 @@ const effectMonsters = {
       text: "Pyro/Effect – <effect=Trigger>When this card is sent to the Graveyard: Your opponent gains 1000 Life Points.</effect>"
    },
    "Cannonball Spear Shellfish": {
+      id: "95614612",
       cardType: EFFECT_MONSTER,
       attribute: WATER,
       levelOrSubtype: 2,
@@ -496,6 +555,7 @@ const effectMonsters = {
       text: 'Aqua/Effect – <effect=Continuous>If "Umi" is on the field, this card is unaffected by Spell effects.</effect>'
    },
    "Cat's Ear Tribe": {
+      id: "95841282",
       cardType: EFFECT_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 1,
@@ -504,6 +564,7 @@ const effectMonsters = {
       text: "Beast-Warrior/Effect – <effect=Continuous>During your opponent's Battle Phase, if a monster(s) your opponent controls battles this card, that monster's original ATK becomes 200 during damage calculation only.</effect>"
    },
    "Chaos Command Magician": {
+      id: "72630549",
       cardType: EFFECT_MONSTER,
       attribute: LIGHT,
       levelOrSubtype: 6,
@@ -512,6 +573,7 @@ const effectMonsters = {
       text: "Spellcaster/Effect – <effect=Continuous>Effects of monsters that target this 1 card are negated.</effect>"
    },
    "Chiron the Mage": {
+      id: "16956455",
       cardType: EFFECT_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 4,
@@ -520,6 +582,7 @@ const effectMonsters = {
       text: "Beast-Warrior/Effect – <effect=Ignition>Once per turn: You can discard 1 Spell Card, then target 1 Spell/Trap Card your opponent controls; destroy that target.</effect>"
    },
    "Chopman the Desperate Outlaw": {
+      id: "40884383",
       cardType: EFFECT_MONSTER,
       attribute: DARK,
       levelOrSubtype: 3,
@@ -528,6 +591,7 @@ const effectMonsters = {
       text: "Zombie/Effect – <effect=Trigger>When this card is Flip Summoned: You can target 1 Equip Spell in your Graveyard; equip it to this card.</effect>"
    },
    "Crass Clown": {
+      id: "93889755",
       cardType: EFFECT_MONSTER,
       attribute: DARK,
       levelOrSubtype: 4,
@@ -536,6 +600,7 @@ const effectMonsters = {
       text: "Fiend/Effect – <effect=Trigger>When this card is changed from Defense Position to Attack Position: Target 1 monster your opponent controls; return that target to the hand.</effect>"
    },
    "Creeping Doom Manta": {
+      id: "52571838",
       cardType: EFFECT_MONSTER,
       attribute: WATER,
       levelOrSubtype: 3,
@@ -544,6 +609,7 @@ const effectMonsters = {
       text: "Fish/Effect – <effect=Continuous>When Normal Summoned, Traps cannot be activated.</effect>"
    },
    "D.D. Assailant": {
+      id: "70074904",
       cardType: EFFECT_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 4,
@@ -552,6 +618,7 @@ const effectMonsters = {
       text: "Warrior/Effect – <effect=Trigger>After damage calculation, when this card is destroyed by battle with an opponent's monster: Banish that monster, also banish this card.</effect>"
    },
    "D.D. Crazy Beast": {
+      id: "48148828",
       cardType: EFFECT_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 3,
@@ -560,6 +627,7 @@ const effectMonsters = {
       text: "Beast/Effect – <effect=Trigger>If this card destroys an opponent's monster by battle, after damage calculation: Banish it.</effect>"
    },
    "Dancing Fairy": {
+      id: "90925163",
       cardType: EFFECT_MONSTER,
       attribute: WIND,
       levelOrSubtype: 4,
@@ -569,6 +637,7 @@ const effectMonsters = {
       prepopLP: { hero: 1000 }
    },
    "Dark Cat with White Tail": {
+      id: "08634636",
       cardType: EFFECT_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 2,
@@ -577,6 +646,7 @@ const effectMonsters = {
       text: "Beast/Flip/Effect – <effect=Trigger>FLIP: Target 2 monsters your opponent controls and 1 monster you control; return those targets to the hand.</effect>"
    },
    "Dark Elf": {
+      id: "21417692",
       cardType: EFFECT_MONSTER,
       attribute: DARK,
       levelOrSubtype: 4,
@@ -585,6 +655,7 @@ const effectMonsters = {
       text: "Spellcaster/Effect – <effect=Continuous>This card cannot declare an attack unless you pay 1000 Life Points.</effect>"
    },
    "Dark Jeroid": {
+      id: "90980792",
       cardType: EFFECT_MONSTER,
       attribute: DARK,
       levelOrSubtype: 4,
@@ -593,6 +664,7 @@ const effectMonsters = {
       text: "Fiend/Effect – <effect=Trigger>When this card is Summoned: Target 1 face-up monster on the field; it loses 800 ATK.</effect>"
    },
    "Dark Scorpion Burglars": {
+      id: "40933924",
       cardType: EFFECT_MONSTER,
       attribute: DARK,
       levelOrSubtype: 4,
@@ -614,6 +686,7 @@ const effectMonsters = {
       }
    },
    "Despair from the Dark": {
+      id: "71200730",
       cardType: EFFECT_MONSTER,
       attribute: DARK,
       levelOrSubtype: 8,
@@ -622,6 +695,7 @@ const effectMonsters = {
       text: "Zombie/Effect – <effect=Trigger>When this card is sent from your hand or Deck to your Graveyard by an opponent's card effect: Special Summon this card.</effect>"
    },
    "Dimension Jar": {
+      id: "73414375",
       cardType: EFFECT_MONSTER,
       attribute: DARK,
       levelOrSubtype: 2,
@@ -630,6 +704,7 @@ const effectMonsters = {
       text: "Machine/Flip/Effect – <effect=Trigger>FLIP: Both players can banish up to 3 cards from their opponent's Graveyard.</effect>"
    },
    "Double Coston": {
+      id: "44436472",
       cardType: EFFECT_MONSTER,
       attribute: DARK,
       levelOrSubtype: 4,
@@ -638,6 +713,7 @@ const effectMonsters = {
       text: "Zombie/Effect – <effect=Continuous>This card can be treated as 2 Tributes for the Tribute Summon of a DARK monster.</effect>"
    },
    "Dragon Manipulator": {
+      id: "63018132",
       cardType: EFFECT_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 3,
@@ -646,6 +722,7 @@ const effectMonsters = {
       text: "Warrior/Flip/Effect – <effect=Trigger>FLIP: Target 1 Dragon monster your opponent controls; take control of that target until the end of this turn.</effect>"
    },
    "Dream Clown": {
+      id: "13215230",
       cardType: EFFECT_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 3,
@@ -654,6 +731,7 @@ const effectMonsters = {
       text: "Warrior/Effect – <effect=Trigger>When this card is changed from Attack Position to Defense Position: Target 1 monster your opponent controls; destroy that target.</effect>"
    },
    Dreamsprite: {
+      id: "08687195",
       cardType: EFFECT_MONSTER,
       attribute: LIGHT,
       levelOrSubtype: 2,
@@ -662,6 +740,7 @@ const effectMonsters = {
       text: "Plant/Effect – <effect=Trigger>Before damage calculation, if this card is targeted for an attack: Target 1 other monster you control; switch the attack target to that target, then apply damage calculation.</effect>"
    },
    "Eagle Eye": {
+      id: "53693416",
       cardType: EFFECT_MONSTER,
       attribute: WIND,
       levelOrSubtype: 3,
@@ -670,6 +749,7 @@ const effectMonsters = {
       text: "Winged Beast/Effect – <effect=Continuous>When Normal Summoned, Traps cannot be activated.</effect>"
    },
    "Electric Lizard": {
+      id: "55875323",
       cardType: EFFECT_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 3,
@@ -678,6 +758,7 @@ const effectMonsters = {
       text: "Thunder/Effect – <effect=Trigger>If this card was attacked by a non Zombie monster, after damage calculation: Next turn, that monster cannot attack.</effect>"
    },
    "Electric Snake": {
+      id: "11324436",
       cardType: EFFECT_MONSTER,
       attribute: LIGHT,
       levelOrSubtype: 3,
@@ -686,6 +767,7 @@ const effectMonsters = {
       text: "Thunder/Effect – <effect=Trigger>When this card is discarded your hand to the Graveyard by an opponent's card effect: Draw 2 cards.</effect>"
    },
    "Elephant Statue of Blessing": {
+      id: "85166216",
       cardType: EFFECT_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 3,
@@ -694,6 +776,7 @@ const effectMonsters = {
       text: "Rock/Effect – <effect=Trigger>When this card is sent from your hand to your Graveyard by an opponent's card effect: Gain 2000 Life Points.</effect>"
    },
    "Elephant Statue of Disaster": {
+      id: "12160911",
       cardType: EFFECT_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 3,
@@ -702,6 +785,7 @@ const effectMonsters = {
       text: "Rock/Effect – <effect=Trigger>When this card is sent from your hand to your Graveyard by an opponent's card effect: Inflict 2000 damage to your opponent.</effect>"
    },
    "Emes the Infinity": {
+      id: "43580269",
       cardType: EFFECT_MONSTER,
       attribute: LIGHT,
       levelOrSubtype: 7,
@@ -710,6 +794,7 @@ const effectMonsters = {
       text: "Machine/Effect – <effect=Trigger>If this card destroys an opponent's monster by battle and sends it to the Graveyard: This card gains 700 ATK.</effect>"
    },
    "Emissary of the Oasis": {
+      id: "06103294",
       cardType: EFFECT_MONSTER,
       attribute: LIGHT,
       levelOrSubtype: 3,
@@ -718,6 +803,7 @@ const effectMonsters = {
       text: "Spellcaster/Effect – <effect=Continuous>While you control a Level 3 or lower Normal Monster, your opponent cannot target this card for an attack.</effect> <effect=Continuous>Any battle damage to the controller of this card from battles involving a Level 3 or lower Normal Monster becomes 0.</effect>"
    },
    "Fairy King Truesdale": {
+      id: "45425051",
       cardType: EFFECT_MONSTER,
       attribute: WATER,
       levelOrSubtype: 6,
@@ -726,6 +812,7 @@ const effectMonsters = {
       text: "Plant/Effect – <effect=Continuous>While this card is in Defense Position, Plant monsters you control gain 500 ATK/DEF.</effect>"
    },
    "Fear from the Dark": {
+      id: "34193084",
       cardType: EFFECT_MONSTER,
       attribute: DARK,
       levelOrSubtype: 4,
@@ -734,6 +821,7 @@ const effectMonsters = {
       text: "Zombie/Effect – <effect=Trigger>When this card is sent from your hand or Deck to your Graveyard by an opponent's card effect: Special Summon this card.</effect>"
    },
    "Fire Princess": {
+      id: "64752646",
       cardType: EFFECT_MONSTER,
       attribute: FIRE,
       levelOrSubtype: 4,
@@ -743,6 +831,7 @@ const effectMonsters = {
       prepopLP: { villain: -500 }
    },
    Firebird: {
+      id: "87473172",
       cardType: EFFECT_MONSTER,
       attribute: FIRE,
       levelOrSubtype: 4,
@@ -751,6 +840,7 @@ const effectMonsters = {
       text: "Winged Beast/Effect – <effect=Trigger>If a Winged-Beast monster(s) you control is destroyed: This card gains 500 ATK.</effect>"
    },
    "Fushi No Tori": {
+      id: "38538445",
       cardType: EFFECT_MONSTER,
       attribute: FIRE,
       levelOrSubtype: 4,
@@ -759,6 +849,7 @@ const effectMonsters = {
       text: "Winged Beast/Spirit/Effect – <effect=Summon>Cannot be Special Summoned.</effect> <effect=Trigger>When this card inflicts battle damage to your opponent: Gain Life Points equal to the battle damage inflicted.</effect> <effect=Trigger>Once per turn, during the End Phase, if this card was Normal Summoned or flipped face-up this turn: Return it to the hand.</effect>"
    },
    "Ghost Knight of Jackal": {
+      id: "13386503",
       cardType: EFFECT_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 5,
@@ -767,6 +858,7 @@ const effectMonsters = {
       text: "Beast-Warrior/Effect – <effect=Trigger>When this card destroys an opponent's monster by battle and sends it to the Graveyard: You can target that destroyed monster in your opponent's Graveyard; Special Summon that target to your side of the field in face-up Defense Position.</effect>"
    },
    "Giant Axe Mummy": {
+      id: "78266168",
       cardType: EFFECT_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 5,
@@ -775,6 +867,7 @@ const effectMonsters = {
       text: "Zombie/Effect – <effect=Ignition>Once per turn: You can change this card to face-down Defense Position.</effect> <effect=Trigger>If this card is attacked by an opponent's monster whose ATK is lower than this card's DEF: Destroy the attacking monster at the end of the Damage Step.</effect>"
    },
    "Goblin Attack Force": {
+      id: "78658564",
       cardType: EFFECT_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 4,
@@ -783,6 +876,7 @@ const effectMonsters = {
       text: "Warrior/Effect – <effect=Continuous>If this card attacks, it is changed to Defense Position at the end of the Battle Phase, and its battle position cannot be changed until the end of your next turn.</effect>"
    },
    "Goblin King": {
+      id: "18590133",
       cardType: EFFECT_MONSTER,
       attribute: DARK,
       levelOrSubtype: 1,
@@ -791,6 +885,7 @@ const effectMonsters = {
       text: "Fiend/Effect – <effect=Continuous>While you control another Fiend monster, this card cannot be attacked.</effect> <effect=Continuous>This card's ATK/DEF become equal to the number of other Fiend monsters on the field x 1000.</effect>"
    },
    "Goblin of Greed": {
+      id: "0425934",
       cardType: EFFECT_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 4,
@@ -799,6 +894,7 @@ const effectMonsters = {
       text: "Fiend/Effect – <effect=Continuous>Neither player can activate cards or effects that would make them discard a card(s) as a cost.</effect>"
    },
    "Gora Turtle": {
+      id: "80233946",
       cardType: EFFECT_MONSTER,
       attribute: WATER,
       levelOrSubtype: 3,
@@ -807,6 +903,7 @@ const effectMonsters = {
       text: "Aqua/Effect – <effect=Continuous>Monsters with 1900 or more ATK cannot attack.</effect>"
    },
    "Gora Turtle of Illusion": {
+      id: "42868711",
       cardType: EFFECT_MONSTER,
       attribute: WATER,
       levelOrSubtype: 4,
@@ -815,6 +912,7 @@ const effectMonsters = {
       text: "Aqua/Effect – <effect=Continuous>Negate any of your opponent's Spell/Trap effects that target this face-up card.</effect>"
    },
    "Gravekeeper's Guard": {
+      id: "37101832",
       cardType: EFFECT_MONSTER,
       attribute: DARK,
       levelOrSubtype: 4,
@@ -823,6 +921,7 @@ const effectMonsters = {
       text: "Spellcaster/Flip/Effect – <effect=Trigger>FLIP: Target 1 monster your opponent controls; return that target to the hand.</effect>"
    },
    "Gravekeeper's Spy": {
+      id: "24317029",
       cardType: EFFECT_MONSTER,
       attribute: DARK,
       levelOrSubtype: 4,
@@ -845,6 +944,7 @@ const effectMonsters = {
       }
    },
    "Great Long Nose": {
+      id: "02356994",
       cardType: EFFECT_MONSTER,
       attribute: DARK,
       levelOrSubtype: 5,
@@ -853,6 +953,7 @@ const effectMonsters = {
       text: "Beast-Warrior/Spirit/Effect – <effect=Summon>Cannot be Special Summoned.</effect> <effect=Trigger>If this card inflicts battle damage to your opponent: Your opponent skips their next Battle Phase.</effect> <effect=Trigger>Once per turn, during the End Phase, if this card was Normal Summoned or flipped face-up this turn: Return it to the hand.</effect>"
    },
    "Great Maju Garzett": {
+      id: "47942531",
       cardType: EFFECT_MONSTER,
       attribute: DARK,
       levelOrSubtype: 6,
@@ -861,6 +962,7 @@ const effectMonsters = {
       text: "Fiend/Effect – <effect=Continuous>This card's ATK becomes twice 1 monster Tributed for the Tribute Summon of this card.</effect>"
    },
    Greenkappa: {
+      id: "61831093",
       cardType: EFFECT_MONSTER,
       attribute: DARK,
       levelOrSubtype: 3,
@@ -869,6 +971,7 @@ const effectMonsters = {
       text: "Warrior/Flip/Effect – <effect=Trigger>FLIP: Target 2 Set Spell/Trap Cards on the field; destroy those targets.</effect>"
    },
    "Guardian Angel Joan": {
+      id: "68007326",
       cardType: EFFECT_MONSTER,
       attribute: LIGHT,
       levelOrSubtype: 7,
@@ -877,6 +980,7 @@ const effectMonsters = {
       text: "Fairy/Effect – <effect=Trigger>When this card destroys a monster by battle and sends it to the Graveyard: Gain Life Points equal to the original ATK of that destroyed monster in the Graveyard.</effect>"
    },
    "Guardian Sphinx": {
+      id: "40659562",
       cardType: EFFECT_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 5,
@@ -885,6 +989,7 @@ const effectMonsters = {
       text: "Rock/Effect – <effect=Ignition>Once per turn: You can change this card to face-down Defense Position.</effect> <effect=Trigger>When this card is Flip Summoned: Return all monsters your opponent controls to the hand.</effect>"
    },
    "Gyaku-Gire Panda": {
+      id: "09817927",
       cardType: EFFECT_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 3,
@@ -893,6 +998,7 @@ const effectMonsters = {
       text: "Beast/Effect – <effect=Continuous>Gains 500 ATK for each monster your opponent controls.</effect> <effect=Continuous>If this card attacks a Defense Position monster, inflict piercing battle damage to your opponent."
    },
    "Cure Mermaid": {
+      id: "85802526",
       cardType: EFFECT_MONSTER,
       attribute: WATER,
       levelOrSubtype: 4,
@@ -902,6 +1008,7 @@ const effectMonsters = {
       prepopLP: { hero: 800 }
    },
    "Hysteric Fairy": {
+      id: "21297224",
       cardType: EFFECT_MONSTER,
       attribute: LIGHT,
       levelOrSubtype: 4,
@@ -911,6 +1018,7 @@ const effectMonsters = {
       prepopLP: { hero: 1000 }
    },
    "Nuvia the Wicked": {
+      id: "12953226",
       cardType: EFFECT_MONSTER,
       attribute: DARK,
       levelOrSubtype: 4,
@@ -919,6 +1027,7 @@ const effectMonsters = {
       text: "Fiend/Effect – <effect=Trigger>If this monster is Normal Summoned, destroy this card.</effect> <effect=Continuous>If your opponent controls any monster, decrease the ATK of this card by 200 points for each monster on your opponent's side of the field.</effect>"
    },
    "The Forgiving Maiden": {
+      id: "84080938",
       cardType: EFFECT_MONSTER,
       attribute: LIGHT,
       levelOrSubtype: 4,
@@ -927,6 +1036,7 @@ const effectMonsters = {
       text: "Fairy/Effect – <effect=Ignition>Offer this face-up card as a Tribute to return 1 of your monsters destroyed in battle during this turn to your hand.</effect>"
    },
    "Hade-Hane": {
+      id: "28357177",
       cardType: EFFECT_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 6,
@@ -935,6 +1045,7 @@ const effectMonsters = {
       text: "Beast/Flip/Effect – <effect=Trigger>FLIP: You can target up to 3 monsters on the field; return those targets to the hand.</effect>"
    },
    "Hand of Nephthys": {
+      id: "98446407",
       cardType: EFFECT_MONSTER,
       attribute: WIND,
       levelOrSubtype: 2,
@@ -943,6 +1054,7 @@ const effectMonsters = {
       text: 'Spellcaster/Effect – <effect=Ignition>You can Tribute this card and 1 other monster; Special Summon 1 "Sacred Phoenix of Nephthys" from your hand or Deck.</effect>'
    },
    "Harpie Lady Sisters": {
+      id: "12206212",
       cardType: EFFECT_MONSTER,
       attribute: WIND,
       levelOrSubtype: 6,
@@ -951,6 +1063,7 @@ const effectMonsters = {
       text: 'Winged Beast/Effect – <effect=Summon>Cannot be Normal Summoned/Set.</effect> <effect=Summon>Must first be Special Summoned with "Elegant Egotist".</effect>'
    },
    "Hayabusa Knight": {
+      id: "21015833",
       cardType: EFFECT_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 3,
@@ -959,6 +1072,7 @@ const effectMonsters = {
       text: "Warrior/Effect – <effect=Continuous>This card can make a second attack during each Battle Phase.</effect>"
    },
    "Helping Robo for Combat": {
+      id: "47025270",
       cardType: EFFECT_MONSTER,
       attribute: LIGHT,
       levelOrSubtype: 4,
@@ -967,6 +1081,7 @@ const effectMonsters = {
       text: "Machine/Effect – <effect=Trigger>When this card destroys an opponent's monster by battle: Draw 1 card, then return 1 card from your hand to the bottom of the Deck.</effect>"
    },
    Hyena: {
+      id: "22873798",
       cardType: EFFECT_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 3,
@@ -987,6 +1102,7 @@ const effectMonsters = {
       }
    },
    "Inaba White Rabbit": {
+      id: "77084837",
       cardType: EFFECT_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 3,
@@ -995,6 +1111,7 @@ const effectMonsters = {
       text: "Beast/Spirit/Effect – <effect=Summon>Cannot be Special Summoned.</effect> <effect=Continuous>This card can attack directly.</effect> <effect=Trigger>Once per turn, during the End Phase, if this card was Normal Summoned or flipped face-up this turn: Return it to the hand.</effect>"
    },
    "Invasion of Flames": {
+      id: "26082229",
       cardType: EFFECT_MONSTER,
       attribute: FIRE,
       levelOrSubtype: 3,
@@ -1003,6 +1120,7 @@ const effectMonsters = {
       text: "Pyro/Effect – <effect=Continuous>When Normal Summoned, Traps cannot be activated.</effect>"
    },
    "Jinzo #7": {
+      id: "32809211",
       cardType: EFFECT_MONSTER,
       attribute: DARK,
       levelOrSubtype: 2,
@@ -1011,6 +1129,7 @@ const effectMonsters = {
       text: "Machine/Effect – <effect=Continuous>This card can attack directly.</effect>"
    },
    "Kaiser Sea Horse": {
+      id: "17444133",
       cardType: EFFECT_MONSTER,
       attribute: LIGHT,
       levelOrSubtype: 4,
@@ -1019,6 +1138,7 @@ const effectMonsters = {
       text: "Sea Serpent/Effect – <effect=Continuous>This card can be treated as 2 Tributes for the Tribute Summon of a LIGHT monster.</effect>"
    },
    "Kangaroo Champ": {
+      id: "95789089",
       cardType: EFFECT_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 4,
@@ -1027,6 +1147,7 @@ const effectMonsters = {
       text: "Beast/Effect – <effect=Trigger>If this card battles a monster: that monster is changed to Defense Position after damage calculation.</effect>"
    },
    Keldo: {
+      id: "80441106",
       cardType: EFFECT_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 4,
@@ -1035,6 +1156,7 @@ const effectMonsters = {
       text: "Fairy/Effect – <effect=Trigger>When this card is destroyed by battle and sent to the Graveyard: Target 2 cards in your opponent's Graveyard; shuffle them into the Deck.</effect>"
    },
    Kiseitai: {
+      id: "04266839",
       cardType: EFFECT_MONSTER,
       attribute: DARK,
       levelOrSubtype: 2,
@@ -1043,6 +1165,7 @@ const effectMonsters = {
       text: "Fiend/Effect – <effect=Trigger>When your opponent's monster attacks this face-down Defense Position card: This card becomes an Equip Spell equipped to the attacking monster.</effect> <effect=Trigger-like>Once per turn, during your opponent's Standby Phase: Gain Life Points equal to half the equipped monster's ATK.</effect>"
    },
    "Lady Ninja Yae": {
+      id: "82005435",
       cardType: EFFECT_MONSTER,
       attribute: WIND,
       levelOrSubtype: 3,
@@ -1051,6 +1174,7 @@ const effectMonsters = {
       text: "Warrior/Effect – <effect=Ignition>You can discard 1 WIND monster to the Graveyard; return all Spells/Traps your opponent controls to the hand.</effect>"
    },
    "Lava Battleguard": {
+      id: "20394040",
       cardType: EFFECT_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 5,
@@ -1059,6 +1183,7 @@ const effectMonsters = {
       text: 'Warrior/Effect – <effect=Continuous>Gains 500 ATK for each "Swamp Battleguard" you control.</effect>'
    },
    Leghul: {
+      id: "12472242",
       cardType: EFFECT_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 1,
@@ -1067,6 +1192,7 @@ const effectMonsters = {
       text: "Insect/Effect – <effect=Continuous>This card can attack directly.</effect>"
    },
    "Mad Sword Beast": {
+      id: "79870141",
       cardType: EFFECT_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 4,
@@ -1075,6 +1201,7 @@ const effectMonsters = {
       text: "Dinosaur/Effect – <effect=Continuous>If this card attacks a Defense Position monster, inflict piercing battle damage to your opponent.</effect>"
    },
    "Magical Plant Mandragola": {
+      id: "07802006",
       cardType: EFFECT_MONSTER,
       attribute: DARK,
       levelOrSubtype: 2,
@@ -1083,6 +1210,7 @@ const effectMonsters = {
       text: "Spellcaster/Flip/Effect – <effect=Flip>FLIP: Place 1 Spell Counter on each face-up card on the field that you can place a Spell Counter on.</effect>"
    },
    "Maha Vailo": {
+      id: "93013676",
       cardType: EFFECT_MONSTER,
       attribute: LIGHT,
       levelOrSubtype: 4,
@@ -1091,6 +1219,7 @@ const effectMonsters = {
       text: "Spellcaster/Effect – <effect=Continuous>Gains 500 ATK for each Equip Card equipped to this card.</effect>"
    },
    "Maju Garzett": {
+      id: "08794435",
       cardType: EFFECT_MONSTER,
       attribute: DARK,
       levelOrSubtype: 7,
@@ -1099,6 +1228,7 @@ const effectMonsters = {
       text: "Fiend/Effect – <effect=Continuous>This Tribute Summoned card's ATK becomes the 2 Tributed monsters' combined original ATKs.</effect>"
    },
    "Masked Dragon": {
+      id: "39191307",
       cardType: EFFECT_MONSTER,
       attribute: FIRE,
       levelOrSubtype: 3,
@@ -1125,6 +1255,7 @@ const effectMonsters = {
       }
    },
    "Mefist the Infernal General": {
+      id: "46820049",
       cardType: EFFECT_MONSTER,
       attribute: DARK,
       levelOrSubtype: 5,
@@ -1140,6 +1271,7 @@ const effectMonsters = {
       }
    },
    "Milus Radiant": {
+      id: "07489323",
       cardType: EFFECT_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 1,
@@ -1148,6 +1280,7 @@ const effectMonsters = {
       text: "Beast/Effect – <effect=Continuous>All EARTH monsters on the field gain 500 ATK, also all WIND monsters on the field lose 400 ATK.</effect>"
    },
    "Mysterious Puppeteer": {
+      id: "54098121",
       cardType: EFFECT_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 4,
@@ -1156,6 +1289,7 @@ const effectMonsters = {
       text: "Warrior/Effect – <effect=Trigger>If a monster is Normal or Flip Summoned: Gain 500 Life Points.</effect>"
    },
    "Mystical Knight of Jackal": {
+      id: "98745000",
       cardType: EFFECT_MONSTER,
       attribute: LIGHT,
       levelOrSubtype: 7,
@@ -1164,6 +1298,7 @@ const effectMonsters = {
       text: "Beast-Warrior/Effect – <effect=Trigger>When this card destroys a monster by battle and sends it to your opponent's Graveyard: You can return it to the top of the Deck.</effect>"
    },
    "Needle Burrower": {
+      id: "98162242",
       cardType: EFFECT_MONSTER,
       attribute: DARK,
       levelOrSubtype: 5,
@@ -1172,6 +1307,7 @@ const effectMonsters = {
       text: "Machine/Effect – <effect=Trigger>When this card destroys a monster by battle and sends it to the Graveyard: Inflict damage to your opponent equal to the monster's original Level x 500.</effect>"
    },
    "Neko Mane King": {
+      id: "11021521",
       cardType: EFFECT_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 1,
@@ -1180,6 +1316,7 @@ const effectMonsters = {
       text: "Beast/Effect – <effect=Trigger>During your opponent's turn, when this card in your possession is sent to your Graveyard by an opponent's card effect: It becomes the End Phase of this turn.</effect>"
    },
    "Nightmare Horse": {
+      id: "59290628",
       cardType: EFFECT_MONSTER,
       attribute: DARK,
       levelOrSubtype: 2,
@@ -1188,6 +1325,7 @@ const effectMonsters = {
       text: "Zombie/Effect – <effect=Continuous>This card can attack directly.</effect>"
    },
    "Shining Angel": {
+      id: "95956346",
       cardType: EFFECT_MONSTER,
       attribute: LIGHT,
       levelOrSubtype: 4,
@@ -1213,6 +1351,7 @@ const effectMonsters = {
       }
    },
    "Mystic Tomato": {
+      id: "83011277",
       cardType: EFFECT_MONSTER,
       attribute: DARK,
       levelOrSubtype: 4,
@@ -1238,6 +1377,7 @@ const effectMonsters = {
       }
    },
    "Giant Rat": {
+      id: "97017120",
       cardType: EFFECT_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 4,
@@ -1263,6 +1403,7 @@ const effectMonsters = {
       }
    },
    "Mother Grizzly": {
+      id: "57839750",
       cardType: EFFECT_MONSTER,
       attribute: WATER,
       levelOrSubtype: 4,
@@ -1288,6 +1429,7 @@ const effectMonsters = {
       }
    },
    "UFO Turtle": {
+      id: "60806437",
       cardType: EFFECT_MONSTER,
       attribute: FIRE,
       levelOrSubtype: 4,
@@ -1313,6 +1455,7 @@ const effectMonsters = {
       }
    },
    "Flying Kamakiri #1": {
+      id: "84834865",
       cardType: EFFECT_MONSTER,
       attribute: WIND,
       levelOrSubtype: 4,
@@ -1338,6 +1481,7 @@ const effectMonsters = {
       }
    },
    "Black Luster Soldier - Envoy of the Beginning": {
+      id: "72989439",
       cardType: EFFECT_MONSTER,
       attribute: LIGHT,
       levelOrSubtype: 8,
@@ -1347,6 +1491,7 @@ const effectMonsters = {
       limit: 1
    },
    "Airknight Parshath": {
+      id: "18036057",
       cardType: EFFECT_MONSTER,
       attribute: LIGHT,
       levelOrSubtype: 5,
@@ -1355,6 +1500,7 @@ const effectMonsters = {
       text: "Fairy/Effect – <effect=Continuous>If this card attacks a Defense Position monster, inflict piercing battle damage.</effect> <effect=Trigger>If this card inflicts battle damage to your opponent: Draw 1 card.</effect>"
    },
    "Magician of Faith": {
+      id: "31560081",
       cardType: EFFECT_MONSTER,
       attribute: LIGHT,
       levelOrSubtype: 1,
@@ -1363,6 +1509,7 @@ const effectMonsters = {
       text: "Spellcaster/Flip/Effect – <effect=Trigger>FLIP: Target 1 Spell in your Graveyard; add that target to your hand.</effect>"
    },
    "Magical Merchant": {
+      id: "32362575",
       cardType: EFFECT_MONSTER,
       attribute: LIGHT,
       levelOrSubtype: 1,
@@ -1385,6 +1532,7 @@ const effectMonsters = {
       }
    },
    "Abyss Soldier": {
+      id: "18318842",
       cardType: EFFECT_MONSTER,
       attribute: WATER,
       levelOrSubtype: 4,
@@ -1394,6 +1542,7 @@ const effectMonsters = {
       limit: 2
    },
    "Breaker the Magical Warrior": {
+      id: "71413901",
       cardType: EFFECT_MONSTER,
       attribute: DARK,
       levelOrSubtype: 4,
@@ -1403,6 +1552,7 @@ const effectMonsters = {
       limit: 1
    },
    Tsukuyomi: {
+      id: "34853266",
       cardType: EFFECT_MONSTER,
       attribute: DARK,
       levelOrSubtype: 4,
@@ -1411,6 +1561,7 @@ const effectMonsters = {
       text: "Spellcaster/Effect – <effect=Summon>Cannot be Special Summoned.</effect> <effect=Trigger>If this card is Normal Summoned or flipped face-up: Target 1 face-up monster on the field; change that target to face-down Defense Position.</effect> <effect=Trigger>Once per turn, during the End Phase, if this card was Normal Summoned or flipped face-up this turn: Return it to the hand.</effect>"
    },
    Sangan: {
+      id: "26202165",
       cardType: EFFECT_MONSTER,
       attribute: DARK,
       levelOrSubtype: 3,
@@ -1434,6 +1585,7 @@ const effectMonsters = {
       limit: 1
    },
    "Sinister Serpent": {
+      id: "08131171",
       cardType: EFFECT_MONSTER,
       attribute: WATER,
       levelOrSubtype: 1,
@@ -1443,6 +1595,7 @@ const effectMonsters = {
       limit: 1
    },
    "Tribe-Infecting Virus": {
+      id: "33184167",
       cardType: EFFECT_MONSTER,
       attribute: WATER,
       levelOrSubtype: 4,
@@ -1452,6 +1605,7 @@ const effectMonsters = {
       limit: 1
    },
    "Morphing Jar": {
+      id: "33508719",
       cardType: EFFECT_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 2,
@@ -1469,6 +1623,7 @@ const effectMonsters = {
       limit: 1
    },
    "Asura Priest": {
+      id: "02134346",
       cardType: EFFECT_MONSTER,
       attribute: LIGHT,
       levelOrSubtype: 4,
@@ -1477,6 +1632,7 @@ const effectMonsters = {
       text: "Fairy/Spirit/Effect – <effect=Summon>Cannot be Special Summoned.</effect> <effect=Trigger>During the End Phase of the turn this card is Normal Summoned or flipped face-up: Return it to the hand.</effect> <effect=Continuous>This card can attack all monsters your opponent controls once each.</effect>"
    },
    "Kycoo the Ghost Destroyer": {
+      id: "88240808",
       cardType: EFFECT_MONSTER,
       attribute: DARK,
       levelOrSubtype: 4,
@@ -1485,6 +1641,7 @@ const effectMonsters = {
       text: "Spellcaster/Effect – <effect=Trigger>When this card inflicts battle damage to your opponent: You can target up to 2 monsters in their Graveyard; banish those targets.</effect> <effect=Continuous>Your opponent cannot banish cards from either Graveyard.</effect>"
    },
    "D.D. Warrior Lady": {
+      id: "07572887",
       cardType: EFFECT_MONSTER,
       attribute: LIGHT,
       levelOrSubtype: 4,
@@ -1494,6 +1651,7 @@ const effectMonsters = {
       limit: 1
    },
    "Chaos Sorcerer": {
+      id: "09596126",
       cardType: EFFECT_MONSTER,
       attribute: DARK,
       levelOrSubtype: 6,
@@ -1502,6 +1660,7 @@ const effectMonsters = {
       text: "Spellcaster/Effect – <effect=Summon>Cannot be Normal Summoned/Set.</effect> <effect=Summon>Must first be Special Summoned (from your hand) by banishing 1 LIGHT and 1 DARK monster from your Graveyard.</effect> <effect=Ignition>Once per turn: You can target 1 face-up monster on the field; banish that target.</effect> <effect=Condition>This card cannot attack the turn you activate this effect.</effect>"
    },
    "Dekoichi the Battlechanted Locomotive": {
+      id: "87621407",
       cardType: EFFECT_MONSTER,
       attribute: DARK,
       levelOrSubtype: 4,
@@ -1510,6 +1669,7 @@ const effectMonsters = {
       text: 'Machine/Flip/Effect – <effect=Trigger>FLIP: Draw 1 card, then draw 1 additional card for each face-up "Bokoichi the Freightening Car" you control.</effect>'
    },
    "Jowgen the Spiritualist": {
+      id: "41855169",
       cardType: EFFECT_MONSTER,
       attribute: LIGHT,
       levelOrSubtype: 3,
@@ -1525,6 +1685,7 @@ const effectMonsters = {
       }
    },
    "Mystic Swordsman LV2": {
+      id: "47507260",
       cardType: EFFECT_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 2,
@@ -1533,6 +1694,7 @@ const effectMonsters = {
       text: 'Warrior/Effect – <effect=Trigger>At the start of the Damage Step, if this card attacked a face-down Defense Position monster: Destroy that monster.</effect> <effect=Trigger>During the End Phase, if this card destroyed a monster by battle this turn: You can send this face-up card to the Graveyard; Special Summon 1 "Mystic Swordsman LV4" from your hand or Deck.</effect>'
    },
    "Roulette Barrel": {
+      id: "46303688",
       cardType: EFFECT_MONSTER,
       attribute: LIGHT,
       levelOrSubtype: 4,
@@ -1549,6 +1711,7 @@ const effectMonsters = {
       }
    },
    "Zaborg the Thunder Monarch": {
+      id: "51945556",
       cardType: EFFECT_MONSTER,
       attribute: LIGHT,
       levelOrSubtype: 5,
@@ -1557,6 +1720,7 @@ const effectMonsters = {
       text: "Thunder/Effect – <effect=Trigger>If this card is Tribute Summoned: Target 1 monster on the field; destroy that target.</effect>"
    },
    "Blade Knight": {
+      id: "39507162",
       cardType: EFFECT_MONSTER,
       attribute: LIGHT,
       levelOrSubtype: 4,
@@ -1565,6 +1729,7 @@ const effectMonsters = {
       text: "Warrior/Effect – <effect=Continuous>While you have 1 or less cards in your hand, this card gains 400 ATK.</effect> <effect=Continuous>If you control no other monsters, the effects of Flip monsters destroyed by battle with this card are negated.</effect>"
    },
    "Don Zaloog": {
+      id: "76922029",
       cardType: EFFECT_MONSTER,
       attribute: DARK,
       levelOrSubtype: 4,
@@ -1580,6 +1745,7 @@ const effectMonsters = {
       }
    },
    "Exiled Force": {
+      id: "74131780",
       cardType: EFFECT_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 4,
@@ -1589,6 +1755,7 @@ const effectMonsters = {
       limit: 1
    },
    "Ninja Grandmaster Sasuke": {
+      id: "04041838",
       cardType: EFFECT_MONSTER,
       attribute: LIGHT,
       levelOrSubtype: 4,
@@ -1597,6 +1764,7 @@ const effectMonsters = {
       text: "Warrior/Effect – <effect=Trigger>At the start of the Damage Step, if this card attacks a face-up Defense Position monster: Destroy that monster.</effect>"
    },
    "Nobleman-Eater Bug": {
+      id: "65878864",
       cardType: EFFECT_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 5,
@@ -1605,6 +1773,7 @@ const effectMonsters = {
       text: "Insect/Flip/Effect – <effect=Trigger>FLIP: Target as many monsters on the field as possible, but no more than 2; destroy them.</effect>"
    },
    "Nubian Guard": {
+      id: "51616747",
       cardType: EFFECT_MONSTER,
       attribute: FIRE,
       levelOrSubtype: 2,
@@ -1613,6 +1782,7 @@ const effectMonsters = {
       text: "Warrior/Effect – <effect=Trigger>If this card inflicts battle damage to your opponent: You can target 1 Continuous Spell in your Graveyard; return it on the top of the Deck.</effect>"
    },
    "Old Vindictive Magician": {
+      id: "45141844",
       cardType: EFFECT_MONSTER,
       attribute: DARK,
       levelOrSubtype: 2,
@@ -1621,6 +1791,7 @@ const effectMonsters = {
       text: "Spellcaster/Flip/Effect – <effect=Flip>FLIP: Target 1 monster your opponent controls; destroy that target.</effect>"
    },
    Ooguchi: {
+      id: "58861941",
       cardType: EFFECT_MONSTER,
       attribute: WATER,
       levelOrSubtype: 1,
@@ -1629,6 +1800,7 @@ const effectMonsters = {
       text: "Aqua/Effect – <effect=Continuous>This card can attack directly.</effect>"
    },
    "Patrician of Darkness": {
+      id: "19153634",
       cardType: EFFECT_MONSTER,
       attribute: DARK,
       levelOrSubtype: 5,
@@ -1637,6 +1809,7 @@ const effectMonsters = {
       text: "Zombie/Effect – <effect=Continuous>You choose the attack targets for your opponent's attacks.</effect>"
    },
    "Penguin Soldier": {
+      id: "93920745",
       cardType: EFFECT_MONSTER,
       attribute: WATER,
       levelOrSubtype: 2,
@@ -1645,6 +1818,7 @@ const effectMonsters = {
       text: "Aqua/Flip/Effect – <effect=Trigger>FLIP: You can target up to 2 monsters on the field; return those targets to the hand.</effect>"
    },
    "Piranha Army": {
+      id: "50823978",
       cardType: EFFECT_MONSTER,
       attribute: WATER,
       levelOrSubtype: 2,
@@ -1653,6 +1827,7 @@ const effectMonsters = {
       text: "Fish/Effect – <effect=Continuous>Damage this card inflicts by direct attacks is doubled.</effect>"
    },
    "Pitch-Black Warwolf": {
+      id: "88975532",
       cardType: EFFECT_MONSTER,
       attribute: DARK,
       levelOrSubtype: 4,
@@ -1661,6 +1836,7 @@ const effectMonsters = {
       text: "Beast-Warrior/Effect – <effect=Continuous>Your opponent cannot activate Trap Cards during the Battle Phase.</effect>"
    },
    "Pixie Knight": {
+      id: "35429292",
       cardType: EFFECT_MONSTER,
       attribute: LIGHT,
       levelOrSubtype: 2,
@@ -1669,6 +1845,7 @@ const effectMonsters = {
       text: "Spellcaster/Effect – <effect=Trigger>When this card is destroyed by battle and sent to the Graveyard: Your opponent targets 1 Spell in your Graveyard; place that card on top of the Deck.</effect>"
    },
    "Poison Mummy": {
+      id: "43716289",
       cardType: EFFECT_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 4,
@@ -1678,6 +1855,7 @@ const effectMonsters = {
       prepopLP: { villain: -500 }
    },
    "Protector of the Sanctuary": {
+      id: "24221739",
       cardType: EFFECT_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 4,
@@ -1687,6 +1865,7 @@ const effectMonsters = {
       limit: 1
    },
    "Queen's Double": {
+      id: "05901497",
       cardType: EFFECT_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 1,
@@ -1695,6 +1874,7 @@ const effectMonsters = {
       text: "Warrior/Effect – <effect=Continuous>This card can attack directly.</effect>"
    },
    "Rainbow Flower": {
+      id: "21347810",
       cardType: EFFECT_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 2,
@@ -1703,6 +1883,7 @@ const effectMonsters = {
       text: "Plant/Effect – <effect=Continuous>This card can attack directly.</effect>"
    },
    "Regenerating Mummy": {
+      id: "70821187",
       cardType: EFFECT_MONSTER,
       attribute: DARK,
       levelOrSubtype: 4,
@@ -1711,6 +1892,7 @@ const effectMonsters = {
       text: "Zombie/Effect – <effect=Trigger>When this card is sent from your hand to your Graveyard by an opponent's card effect: Return this card to the hand.</effect>"
    },
    "Revival Jam": {
+      id: "31709826",
       cardType: EFFECT_MONSTER,
       attribute: WATER,
       levelOrSubtype: 4,
@@ -1720,6 +1902,7 @@ const effectMonsters = {
       prepopLP: { hero: -1000 }
    },
    "Rocket Jumper": {
+      id: "53890795",
       cardType: EFFECT_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 3,
@@ -1728,6 +1911,7 @@ const effectMonsters = {
       text: "Rock/Effect – <effect=Continuous>If your opponent only controls Defense Position monsters, this card can attack directly.</effect>"
    },
    "Berserk Gorilla": {
+      id: "39168895",
       cardType: EFFECT_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 4,
@@ -1736,6 +1920,7 @@ const effectMonsters = {
       text: "Beast/Effect - <effect=Continuous>If this card is in face-up Defense Position, destroy this card.</effect> <effect=Continuous>This card must attack if able.</effect>"
    },
    "Bazoo the Soul-Eater": {
+      id: "40133511",
       cardType: EFFECT_MONSTER,
       attribute: "Earth",
       levelOrSubtype: 4,
@@ -1744,6 +1929,7 @@ const effectMonsters = {
       text: "Beast/Effect - <effect=Ignition>Once per turn: You can banish up to 3 monsters from your Graveyard; this card gains 300 ATK for each, until the end of your opponent's turn.</effect>"
    },
    "Skilled Dark Magician": {
+      id: "73752131",
       cardType: EFFECT_MONSTER,
       attribute: DARK,
       levelOrSubtype: 4,
@@ -1765,6 +1951,7 @@ const effectMonsters = {
       }
    },
    "Thunder Dragon": {
+      id: "31786629",
       cardType: EFFECT_MONSTER,
       attribute: LIGHT,
       levelOrSubtype: 5,
@@ -1785,6 +1972,7 @@ const effectMonsters = {
       }
    },
    "Zombyra the Dark": {
+      id: "88472456",
       cardType: EFFECT_MONSTER,
       attribute: DARK,
       levelOrSubtype: 4,
@@ -1793,6 +1981,7 @@ const effectMonsters = {
       text: "Warrior/Effect – <effect=Continuous>Cannot attack your opponent directly.</effect> <effect=Trigger>If this card destroys a monster by battle: This card loses 200 ATK.</effect>"
    },
    "Armed Dragon LV5": {
+      id: "46384672",
       cardType: EFFECT_MONSTER,
       attribute: WIND,
       levelOrSubtype: 5,
@@ -1814,6 +2003,7 @@ const effectMonsters = {
       }
    },
    "Cave Dragon": {
+      id: "93220472",
       cardType: EFFECT_MONSTER,
       attribute: WIND,
       levelOrSubtype: 4,
@@ -1822,6 +2012,7 @@ const effectMonsters = {
       text: "Dragon/Effect – Cannot be Normal Summoned while you control a monster. <effect=Continuous>This card cannot declare an attack unless you control another Dragon-Type monster.</effect>"
    },
    "Different Dimension Dragon": {
+      id: "50939127",
       cardType: EFFECT_MONSTER,
       attribute: LIGHT,
       levelOrSubtype: 5,
@@ -1830,6 +2021,7 @@ const effectMonsters = {
       text: "Dragon/Effect – <effect=Continuous>This card cannot be destroyed by Spell/Trap effects that do not target it.</effect> <effect=Continuous>This card cannot be destroyed by battle with a monster that has 1900 or less ATK.</effect>"
    },
    "Fusilier Dragon, the Dual-Mode Beast": {
+      id: "51632798",
       cardType: EFFECT_MONSTER,
       attribute: DARK,
       levelOrSubtype: 7,
@@ -1838,6 +2030,7 @@ const effectMonsters = {
       text: "Machine/Effect – You can Normal Summon/Set this card without Tributing, but its original ATK/DEF become halved."
    },
    "Mirage Dragon": {
+      id: "15960641",
       cardType: EFFECT_MONSTER,
       attribute: LIGHT,
       levelOrSubtype: 4,
@@ -1846,6 +2039,7 @@ const effectMonsters = {
       text: "Dragon/Effect – <effect=Continuous>Your opponent cannot activate Traps during the Battle Phase.</effect>"
    },
    "Rare Metal Dragon": {
+      id: "25236056",
       cardType: EFFECT_MONSTER,
       attribute: DARK,
       levelOrSubtype: 4,
@@ -1854,6 +2048,7 @@ const effectMonsters = {
       text: "Dragon/Effect – This card cannot be Normal Summoned or Set."
    },
    "Tyrant Dragon": {
+      id: "94568601",
       cardType: EFFECT_MONSTER,
       attribute: FIRE,
       levelOrSubtype: 8,

--- a/web-app/src/databases/cardDB/monsters/fusionMonsters.js
+++ b/web-app/src/databases/cardDB/monsters/fusionMonsters.js
@@ -2,6 +2,7 @@ import { HERO, VILLAIN, MONSTER, FLIP_COINS, FUSION_MONSTER, DARK, LIGHT, WATER,
 
 const fusions = {
    Bickuribox: {
+      id: "25655502",
       cardType: FUSION_MONSTER,
       attribute: DARK,
       levelOrSubtype: 7,
@@ -10,6 +11,7 @@ const fusions = {
       text: 'Fiend/Fusion – "Crass Clown" + "Dream Clown"'
    },
    "Black Skull Dragon": {
+      id: "11901678",
       cardType: FUSION_MONSTER,
       attribute: DARK,
       levelOrSubtype: 9,
@@ -18,6 +20,7 @@ const fusions = {
       text: 'Dragon/Fusion – "Summoned Skull" + "Red-Eyes Black Dragon". (This card is always treated as an "Archfiend" card.)'
    },
    "Charubin the Fire Knight": {
+      id: "37421579",
       cardType: FUSION_MONSTER,
       attribute: FIRE,
       levelOrSubtype: 3,
@@ -26,6 +29,7 @@ const fusions = {
       text: 'Pyro/Fusion – "Monster Egg" + "Hinotama Soul"'
    },
    "Cyber Saurus": {
+      id: "89112729",
       cardType: FUSION_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 5,
@@ -34,6 +38,7 @@ const fusions = {
       text: 'Machine/Fusion – "Blast Juggler" + "Two-Headed King Rex"'
    },
    "Dark Flare Knight": {
+      id: "13722870",
       cardType: FUSION_MONSTER,
       attribute: DARK,
       levelOrSubtype: 6,
@@ -42,6 +47,7 @@ const fusions = {
       text: 'Warrior/Fusion/Effect – "Dark Magician" + "Flame Swordsman". <effect=Continuous>You take no Battle Damage from battles involving this card.</effect> <effect=Trigger>When this card is destroyed by battle and sent to the Graveyard: Special Summon 1 "Mirage Knight" from your hand or Deck.</effect>'
    },
    "Dark Paladin": {
+      id: "98502113",
       cardType: FUSION_MONSTER,
       attribute: DARK,
       levelOrSubtype: 8,
@@ -51,6 +57,7 @@ const fusions = {
       noMeta: true
    },
    "Deepsea Shark": {
+      id: "28593363",
       cardType: FUSION_MONSTER,
       attribute: WATER,
       levelOrSubtype: 5,
@@ -59,6 +66,7 @@ const fusions = {
       text: 'Fish/Fusion – "Bottom Dweller" + "Tongyo"'
    },
    "Elemental HERO Flame Wingman": {
+      id: "35809262",
       cardType: FUSION_MONSTER,
       attribute: WIND,
       levelOrSubtype: 6,
@@ -68,6 +76,7 @@ const fusions = {
       noMeta: true
    },
    "Elemental HERO Thunder Giant": {
+      id: "61204971",
       cardType: FUSION_MONSTER,
       attribute: LIGHT,
       levelOrSubtype: 6,
@@ -77,6 +86,7 @@ const fusions = {
       noMeta: true
    },
    "Empress Judge": {
+      id: "15237615",
       cardType: FUSION_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 6,
@@ -85,6 +95,7 @@ const fusions = {
       text: 'Warrior/Fusion – "Queen\'s Double" + "Hibikime"'
    },
    "Flame Ghost": {
+      id: "58528964",
       cardType: FUSION_MONSTER,
       attribute: DARK,
       levelOrSubtype: 3,
@@ -93,6 +104,7 @@ const fusions = {
       text: 'Zombie/Fusion – "Skull Servant" + "Dissolverock"'
    },
    "Flame Swordsman": {
+      id: "45231177",
       cardType: FUSION_MONSTER,
       attribute: FIRE,
       levelOrSubtype: 5,
@@ -101,6 +113,7 @@ const fusions = {
       text: 'Warrior/Fusion – "Flame Manipulator" + "Masaki the Legendary Swordsman"'
    },
    "Flower Wolf": {
+      id: "95952802",
       cardType: FUSION_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 5,
@@ -109,6 +122,7 @@ const fusions = {
       text: 'Beast/Fusion – "Silver Fang" + "Darkworld Thorns"'
    },
    Fusionist: {
+      id: "01641882",
       cardType: FUSION_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 3,
@@ -117,6 +131,7 @@ const fusions = {
       text: 'Beast/Fusion – "Petit Angel" + "Mystical Sheep #2"'
    },
    "Gaia the Dragon Champion": {
+      id: "66889139",
       cardType: FUSION_MONSTER,
       attribute: WIND,
       levelOrSubtype: 7,
@@ -125,6 +140,7 @@ const fusions = {
       text: 'Dragon/Fusion – "Gaia The Fierce Knight" + "Curse of Dragon"'
    },
    "Giltia the D. Knight": {
+      id: "51828629",
       cardType: FUSION_MONSTER,
       attribute: LIGHT,
       levelOrSubtype: 5,
@@ -133,6 +149,7 @@ const fusions = {
       text: 'Warrior/Fusion – "Guardian of the Labyrinth" + "Protector of the Throne"'
    },
    "Humanoid Worm Drake": {
+      id: "05600127",
       cardType: FUSION_MONSTER,
       attribute: WATER,
       levelOrSubtype: 7,
@@ -141,6 +158,7 @@ const fusions = {
       text: 'Aqua/Fusion – "Worm Drake" + "Humanoid Slime"'
    },
    "Kaminari Attack": {
+      id: "09653271",
       cardType: FUSION_MONSTER,
       attribute: WIND,
       levelOrSubtype: 5,
@@ -149,6 +167,7 @@ const fusions = {
       text: 'Thunder/Fusion – "Ocubeam" + "Mega Thunderball"'
    },
    "Karbonala Warrior": {
+      id: "54541900",
       cardType: FUSION_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 4,
@@ -157,6 +176,7 @@ const fusions = {
       text: 'Warrior/Fusion – "M-Warrior #1" + "M-Warrior #2"'
    },
    "Kwagar Hercules": {
+      id: "95144193",
       cardType: FUSION_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 6,
@@ -165,6 +185,7 @@ const fusions = {
       text: 'Insect/Fusion – "Kuwagata α" + "Hercules Beetle"'
    },
    "Labyrinth Tank": {
+      id: "99551425",
       cardType: FUSION_MONSTER,
       attribute: DARK,
       levelOrSubtype: 7,
@@ -173,6 +194,7 @@ const fusions = {
       text: 'Machine/Fusion – "Giga-Tech Wolf" + "Cannon Soldier"'
    },
    "Master of Oz": {
+      id: "27134689",
       cardType: FUSION_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 9,
@@ -181,6 +203,7 @@ const fusions = {
       text: 'Beast/Fusion – "Big Koala" + "Des Kangaroo"'
    },
    "Metal Dragon": {
+      id: "09293977",
       cardType: FUSION_MONSTER,
       attribute: WIND,
       levelOrSubtype: 6,
@@ -189,6 +212,7 @@ const fusions = {
       text: 'Machine/Fusion – "Steel Ogre Grotto #1" + "Lesser Dragon"'
    },
    "Mokey Mokey King": {
+      id: "13803864",
       cardType: FUSION_MONSTER,
       attribute: LIGHT,
       levelOrSubtype: 6,
@@ -197,6 +221,7 @@ const fusions = {
       text: 'Fairy/Fusion/Effect – "Mokey Mokey" + "Mokey Mokey" + "Mokey Mokey". <effect=Trigger>When this card leaves the field, you can Special Summon as many "Mokey Mokey" as possible from your Graveyard.</effect>'
    },
    "Musician King": {
+      id: "56907389",
       cardType: FUSION_MONSTER,
       attribute: LIGHT,
       levelOrSubtype: 5,
@@ -205,6 +230,7 @@ const fusions = {
       text: 'Spellcaster/Fusion – "Witch of the Black Forest" + "Lady of Faith"'
    },
    "Punished Eagle": {
+      id: "74703140",
       cardType: FUSION_MONSTER,
       attribute: WIND,
       levelOrSubtype: 6,
@@ -213,6 +239,7 @@ const fusions = {
       text: 'Winged Beast/Fusion – "Blue-Winged Crown" + "Niwatori"'
    },
    "Rabid Horseman": {
+      id: "94905343",
       cardType: FUSION_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 6,
@@ -221,6 +248,7 @@ const fusions = {
       text: 'Beast-Warrior/Fusion – "Battle Ox" + "Mystic Horseman"'
    },
    "Roaring Ocean Snake": {
+      id: "19066538",
       cardType: FUSION_MONSTER,
       attribute: WATER,
       levelOrSubtype: 6,
@@ -229,6 +257,7 @@ const fusions = {
       text: 'Aqua/Fusion – "Mystic Lamp" + "Hyosube"'
    },
    Sanwitch: {
+      id: "53539634",
       cardType: FUSION_MONSTER,
       attribute: DARK,
       levelOrSubtype: 6,
@@ -237,6 +266,7 @@ const fusions = {
       text: 'Spellcaster/Fusion – "Sangan" + "Witch of the Black Forest"'
    },
    "Skull Knight": {
+      id: "02504891",
       cardType: FUSION_MONSTER,
       attribute: DARK,
       levelOrSubtype: 7,
@@ -245,6 +275,7 @@ const fusions = {
       text: 'Spellcaster/Fusion – "Tainted Wisdom" + "Ancient Brain"'
    },
    "St. Joan": {
+      id: "21175632",
       cardType: FUSION_MONSTER,
       attribute: LIGHT,
       levelOrSubtype: 7,
@@ -253,6 +284,7 @@ const fusions = {
       text: 'Fairy/Fusion – "The Forgiving Maiden" + "Darklord Marie"'
    },
    "Super Robolady": {
+      id: "75923050",
       cardType: FUSION_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 6,
@@ -261,6 +293,7 @@ const fusions = {
       text: 'Machine/Fusion/Effect – "Robolady" + "Roboyarou". <effect=Ignition>You can Special Summon "Super Roboyarou" by returning this card from the field to the Extra Deck. You cannot use this effect during the same turn this monster is Special Summoned.</effect> <effect=Trigger>In addition, increase the ATK of this monster by 1000 points during the Damage Step when this monster inflicts Direct Damage to your opponent\'s Life Points.</effect>'
    },
    "Super Roboyarou": {
+      id: "01412158",
       cardType: FUSION_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 6,
@@ -269,6 +302,7 @@ const fusions = {
       text: 'Machine/Fusion/Effect – "Roboyarou" + "Robolady". <effect=Ignition>You can Special Summon "Super Robolady" by returning this card from the field to the Extra Deck. You cannot use this effect during the same turn this monster is Special Summoned.</effect> <effect=Trigger>In addition, increase the ATK of this monster by 1000 points during the Damage Step when this monster battles with a monster.</effect>'
    },
    "Thousand Dragon": {
+      id: "41462083",
       cardType: FUSION_MONSTER,
       attribute: WIND,
       levelOrSubtype: 7,
@@ -277,6 +311,7 @@ const fusions = {
       text: 'Dragon/Fusion – "Time Wizard" + "Baby Dragon"'
    },
    "Twin-Headed Thunder Dragon": {
+      id: "54752875",
       cardType: FUSION_MONSTER,
       attribute: LIGHT,
       levelOrSubtype: 7,
@@ -285,6 +320,7 @@ const fusions = {
       text: 'Thunder/Fusion – "Thunder Dragon" + "Thunder Dragon"'
    },
    "Warrior of Tradition": {
+      id: "56413937",
       cardType: FUSION_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 6,
@@ -293,6 +329,7 @@ const fusions = {
       text: 'Warrior/Fusion – "Sonic Maid" + "Beautiful Headhuntress"'
    },
    "XY-Dragon Cannon": {
+      id: "02111707",
       cardType: FUSION_MONSTER,
       attribute: LIGHT,
       levelOrSubtype: 6,
@@ -302,6 +339,7 @@ const fusions = {
       noMeta: true
    },
    "XYZ-Dragon Cannon": {
+      id: "91998119",
       cardType: FUSION_MONSTER,
       attribute: LIGHT,
       levelOrSubtype: 8,
@@ -311,6 +349,7 @@ const fusions = {
       noMeta: true
    },
    "XZ-Tank Cannon": {
+      id: "99724761",
       cardType: FUSION_MONSTER,
       attribute: LIGHT,
       levelOrSubtype: 6,
@@ -320,6 +359,7 @@ const fusions = {
       noMeta: true
    },
    "YZ-Tank Dragon": {
+      id: "25119460",
       cardType: FUSION_MONSTER,
       attribute: LIGHT,
       levelOrSubtype: 6,
@@ -329,6 +369,7 @@ const fusions = {
       noMeta: true
    },
    "Dragoness the Wicked Knight": {
+      id: "70681994",
       cardType: FUSION_MONSTER,
       attribute: WIND,
       levelOrSubtype: 3,
@@ -337,6 +378,7 @@ const fusions = {
       text: 'Warrior/Fusion – "Armaill" + "One-Eyed Shield Dragon"'
    },
    "King Dragun": {
+      id: "13756293",
       cardType: FUSION_MONSTER,
       attribute: "",
       levelOrSubtype: 7,
@@ -345,6 +387,7 @@ const fusions = {
       text: 'Dragon/Fusion/Effect – "Lord of D." + "Divine Dragon Ragnarok". <effect=Continuous>Your opponent cannot target Dragon monsters with card effects.</effect> <effect=Ignition>Once per turn: You can Special Summon 1 Dragon monster from your hand.</effect>'
    },
    "Darkfire Dragon": {
+      id: "17881964",
       cardType: FUSION_MONSTER,
       attribute: DARK,
       levelOrSubtype: 4,
@@ -353,6 +396,7 @@ const fusions = {
       text: 'Dragon/Effect – "Firegrass" + "Petit Dragon"'
    },
    "Ojama King": {
+      id: "90140980",
       cardType: FUSION_MONSTER,
       attribute: LIGHT,
       levelOrSubtype: 6,
@@ -361,6 +405,7 @@ const fusions = {
       text: 'Beast/Fusion/Effect – "Ojama Green" + "Ojama Yellow" + "Ojama Black". <effect=Continuous>Select up to 3 of your opponent\'s Monster Card Zones. The selected zones cannot be used.</effect>'
    },
    "Reaper on the Nightmare": {
+      id: "85684223",
       cardType: FUSION_MONSTER,
       attribute: DARK,
       levelOrSubtype: 5,
@@ -376,6 +421,7 @@ const fusions = {
       }
    },
    "Fiend Skull Dragon": {
+      id: "66235877",
       cardType: FUSION_MONSTER,
       attribute: WIND,
       levelOrSubtype: 5,
@@ -384,6 +430,7 @@ const fusions = {
       text: 'Dragon/Fusion/Effect – "Cave Dragon" + "Lesser Fiend". <effect=Condition>(This card is always treated as an "Archfiend" card.)</effect> <effect=Summon>A Fusion Summon of this card can only be done with the above Fusion Material Monsters.</effect> <effect=Continuous>Negate the effects of Flip Effect Monsters.</effect> <effect=Continuous>Negate any Trap effects that target this card on the field, and if you do, destroy that Trap Card.</effect>'
    },
    "Dark Blade the Dragon Knight": {
+      id: "86805855",
       cardType: FUSION_MONSTER,
       attribute: DARK,
       levelOrSubtype: 6,
@@ -392,6 +439,7 @@ const fusions = {
       text: 'Warrior/Fusion/Effect – "Dark Blade" + "Pitch-Dark Dragon". <effect=Trigger>When this card inflicts battle damage to your opponent: You can target up to 3 monsters in their Graveyard; banish those targets.</effect>'
    },
    "The Last Warrior from Another Planet": {
+      id: "86099788",
       cardType: FUSION_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 7,
@@ -400,6 +448,7 @@ const fusions = {
       text: 'Warrior/Fusion/Effect – "Zombyra the Dark" + "Maryokutai". <effect=Trigger>If this card is Special Summoned: Destroy all other monsters you control.</effect> <effect=Continuous>Neither player can Summon monsters.</effect>'
    },
    "Gatling Dragon": {
+      id: "87751584",
       cardType: FUSION_MONSTER,
       attribute: DARK,
       levelOrSubtype: 8,
@@ -416,6 +465,7 @@ const fusions = {
       }
    },
    "Ryu Senshi": {
+      id: "49868263",
       cardType: FUSION_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 6,
@@ -424,6 +474,7 @@ const fusions = {
       text: 'Warrior/Fusion/Effect – "Warrior Dai Grepher" + "Spirit Ryu". <effect=Summon>A Fusion Summon of this card can only be done with the above Fusion Materials.</effect> <effect=Quick>When a Normal Trap Card is activated (Quick Effect): You can pay 1000 Life Points; negate that effect. This card must be face-up on the field to activate and to resolve this effect.</effect> <effect=Continuous>Negate the effects of any Spell Card that targets this card and destroy it.</effect>'
    },
    "Dark Balter the Terrible": {
+      id: "80071763",
       cardType: FUSION_MONSTER,
       attribute: DARK,
       levelOrSubtype: 5,
@@ -432,6 +483,7 @@ const fusions = {
       text: 'Fiend/Fusion/Effect – "Possessed Dark Soul" + "Frontier Wiseman". <effect=Summon>A Fusion Summon of this card can only be done with the above Fusion Materials.</effect> <effect=Quick>When a Normal Spell Card is activated (Quick Effect): You can pay 1000 Life Points; negate that effect. This card must be face-up on the field to activate and to resolve this effect.</effect> <effect=Continuous>Negate the effects of monsters destroyed by battle with this card.</effect>'
    },
    "Thousand-Eyes Restrict": {
+      id: "63519819",
       cardType: FUSION_MONSTER,
       attribute: DARK,
       levelOrSubtype: 1,

--- a/web-app/src/databases/cardDB/monsters/normalMonsters.js
+++ b/web-app/src/databases/cardDB/monsters/normalMonsters.js
@@ -2,6 +2,7 @@ import { NORMAL_MONSTER, DARK, LIGHT, WATER, FIRE, EARTH, WIND } from "utils/con
 
 const normalMonsters = {
    "7 Colored Fish": {
+      id: "23771716",
       cardType: NORMAL_MONSTER,
       attribute: WATER,
       levelOrSubtype: 4,
@@ -10,6 +11,7 @@ const normalMonsters = {
       text: "Fish – A rare rainbow fish that has never been caught by mortal man"
    },
    "Acrobat Monkey": {
+      id: "47372349",
       cardType: NORMAL_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 3,
@@ -18,6 +20,7 @@ const normalMonsters = {
       text: "Machine – An autonomous monkey type robot which was developed with cutting-edge technology. It moves very acrobatically."
    },
    Aitsu: {
+      id: "48202661",
       cardType: NORMAL_MONSTER,
       attribute: FIRE,
       levelOrSubtype: 5,
@@ -26,6 +29,7 @@ const normalMonsters = {
       text: "Fairy – He seems to be very unreliable, but he might have incredible potential."
    },
    "Alpha The Magnet Warrior": {
+      id: "99785935",
       cardType: NORMAL_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 4,
@@ -34,6 +38,7 @@ const normalMonsters = {
       text: "Rock – Alpha, Beta, and Gamma meld as one to form a powerful monster."
    },
    "Amphibian Beast": {
+      id: "67371383",
       cardType: NORMAL_MONSTER,
       attribute: WATER,
       levelOrSubtype: 6,
@@ -42,6 +47,7 @@ const normalMonsters = {
       text: "Fish – On land or in the sea, the speed of this monster is unmatchable."
    },
    "Ancient Brain": {
+      id: "42431843",
       cardType: NORMAL_MONSTER,
       attribute: DARK,
       levelOrSubtype: 3,
@@ -50,6 +56,7 @@ const normalMonsters = {
       text: "Fiend – A fallen fairy that is powerful in the dark."
    },
    "Ancient Elf": {
+      id: "93221206",
       cardType: NORMAL_MONSTER,
       attribute: LIGHT,
       levelOrSubtype: 4,
@@ -58,6 +65,7 @@ const normalMonsters = {
       text: "Spellcaster – This elf is rumored to have lived for thousands of years. He leads an army of spirits against his enemies."
    },
    "Ancient Lizard Warrior": {
+      id: "43230671",
       cardType: NORMAL_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 4,
@@ -66,6 +74,7 @@ const normalMonsters = {
       text: "Reptile – Before the dawn of time, this lizard warrior reigned supreme."
    },
    "Ancient One of the Deep Forest": {
+      id: "14015067",
       cardType: NORMAL_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 6,
@@ -74,6 +83,7 @@ const normalMonsters = {
       text: "Beast – This creature adopts the form of a white goat living in the forest, but is actually a Forest Elder."
    },
    Ansatsu: {
+      id: "48365709",
       cardType: NORMAL_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 5,
@@ -82,6 +92,7 @@ const normalMonsters = {
       text: "Warrior – A silent and deadly warrior specializing in assassinations."
    },
    "Aqua Madoor": {
+      id: "85639257",
       cardType: NORMAL_MONSTER,
       attribute: WATER,
       levelOrSubtype: 4,
@@ -90,6 +101,7 @@ const normalMonsters = {
       text: "Spellcaster – A wizard of the waters that conjures a liquid wall to crush any enemies that oppose him."
    },
    "Archfiend Marmot of Nefariousness": {
+      id: "75889523",
       cardType: NORMAL_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 2,
@@ -98,6 +110,7 @@ const normalMonsters = {
       text: "Beast – An air marmot that has a nefarious horna dnwings. It attacks by throwing acorns."
    },
    "Archfiend Soldier": {
+      id: "49881766",
       cardType: NORMAL_MONSTER,
       attribute: DARK,
       levelOrSubtype: 4,
@@ -106,6 +119,7 @@ const normalMonsters = {
       text: "Fiend – An expert at battle who belongs to a crack diabolical unit. He's famous because he always gets the job done."
    },
    Armaill: {
+      id: "53153481",
       cardType: NORMAL_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 3,
@@ -114,6 +128,7 @@ const normalMonsters = {
       text: "Warrior – A strange warrior who manipulates three deadly blades with both hands and his tail."
    },
    "Armored Lizard": {
+      id: "15480588",
       cardType: NORMAL_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 4,
@@ -122,6 +137,7 @@ const normalMonsters = {
       text: "Reptile – A lizard with a very tough hide and a vicious bite."
    },
    "Armored Starfish": {
+      id: "17535588",
       cardType: NORMAL_MONSTER,
       attribute: WATER,
       levelOrSubtype: 4,
@@ -130,6 +146,7 @@ const normalMonsters = {
       text: "Aqua – A bluish starfish with a solid hide capable of fending off attacks."
    },
    "Armored Zombie": {
+      id: "20277860",
       cardType: NORMAL_MONSTER,
       attribute: DARK,
       levelOrSubtype: 3,
@@ -138,6 +155,7 @@ const normalMonsters = {
       text: "Zombie – This warrior blindly swings a deadly blade with devastating force."
    },
    "Axe Raider": {
+      id: "48305365",
       cardType: NORMAL_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 4,
@@ -146,6 +164,7 @@ const normalMonsters = {
       text: "Warrior – An axe-wielding monster of tremendous strength and agility."
    },
    "Baby Dragon": {
+      id: "88819587",
       cardType: NORMAL_MONSTER,
       attribute: WIND,
       levelOrSubtype: 3,
@@ -154,6 +173,7 @@ const normalMonsters = {
       text: "Dragon – Much more than just a child, this dragon is gifted with untapped power."
    },
    "Baron of the Fiend Sword": {
+      id: "86325596",
       cardType: NORMAL_MONSTER,
       attribute: DARK,
       levelOrSubtype: 4,
@@ -162,6 +182,7 @@ const normalMonsters = {
       text: "Fiend – An aristocrat who wields a sword possessed by a malicious spirit that preys on the weak."
    },
    "Basic Insect": {
+      id: "89091579",
       cardType: NORMAL_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 2,
@@ -170,6 +191,7 @@ const normalMonsters = {
       text: "Insect – Usually found traveling in swarms, this creature's ideal environment is the forest."
    },
    "Battle Footballer": {
+      id: "48094997",
       cardType: NORMAL_MONSTER,
       attribute: FIRE,
       levelOrSubtype: 4,
@@ -178,6 +200,7 @@ const normalMonsters = {
       text: "Machine – A cyborg with high defense power. Originally it was invented for a football machine."
    },
    "Battle Ox": {
+      id: "05053103",
       cardType: NORMAL_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 4,
@@ -186,6 +209,7 @@ const normalMonsters = {
       text: "Beast-Warrior – A monster with tremendous power, it destroys enemies with a swing of its axe."
    },
    "Battle Steer": {
+      id: "18246479",
       cardType: NORMAL_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 5,
@@ -194,6 +218,7 @@ const normalMonsters = {
       text: "Beast-Warrior – A bull monster often found in the woods, it charges enemy monsters with a pair of deadly horns."
    },
    "Bean Soldier": {
+      id: "84990171",
       cardType: NORMAL_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 4,
@@ -202,6 +227,7 @@ const normalMonsters = {
       text: "Plant – A plant-warrior that attacks with seeds and sword."
    },
    "Beast of Talwar": {
+      id: "11761845",
       cardType: NORMAL_MONSTER,
       attribute: DARK,
       levelOrSubtype: 6,
@@ -210,6 +236,7 @@ const normalMonsters = {
       text: "Fiend – Only the master of the sword among Fiend-Type monsters is permitted to hold the Talwar."
    },
    "Beautiful Headhuntress": {
+      id: "16899564",
       cardType: NORMAL_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 4,
@@ -218,6 +245,7 @@ const normalMonsters = {
       text: "Warrior – A vicious creature that has decapitated numerous enemy monsters."
    },
    "Beaver Warrior": {
+      id: "32452818",
       cardType: NORMAL_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 4,
@@ -226,6 +254,7 @@ const normalMonsters = {
       text: "Beast-Warrior – What this creature lacks in size it makes up for in defense when battling in the prairie."
    },
    "Beta The Magnet Warrior": {
+      id: "39256679",
       cardType: NORMAL_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 4,
@@ -234,6 +263,7 @@ const normalMonsters = {
       text: "Rock – Alpha, Beta, and Gamma meld as one to form a powerful monster."
    },
    "Big Koala": {
+      id: "42129512",
       cardType: NORMAL_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 7,
@@ -242,6 +272,7 @@ const normalMonsters = {
       text: "Beast – A species of huge Des Koala. He's meek, but people are afraid of him because he's very powerful."
    },
    "Bio-Mage": {
+      id: "58696829",
       cardType: NORMAL_MONSTER,
       attribute: LIGHT,
       levelOrSubtype: 3,
@@ -250,6 +281,7 @@ const normalMonsters = {
       text: "Fairy – A mysterious priest created as a result of the latest advances in biotechnology."
    },
    "Blackland Fire Dragon": {
+      id: "87564352",
       cardType: NORMAL_MONSTER,
       attribute: DARK,
       levelOrSubtype: 4,
@@ -258,6 +290,7 @@ const normalMonsters = {
       text: "Dragon – A dragon that dwells in the depths of darkness, its vulnerability lies in its poor eyesight."
    },
    "Blazing Inpachi": {
+      id: "05464695",
       cardType: NORMAL_MONSTER,
       attribute: FIRE,
       levelOrSubtype: 4,
@@ -266,6 +299,7 @@ const normalMonsters = {
       text: "Pyro – A wicked wooden spirit now burning in flames. Its fire attack is powerful, but it will soon be nothing but ashes."
    },
    "Blue-Eyes White Dragon": {
+      id: "89631139",
       cardType: NORMAL_MONSTER,
       attribute: LIGHT,
       levelOrSubtype: 8,
@@ -274,6 +308,7 @@ const normalMonsters = {
       text: "Dragon – This legendary dragon is a powerful engine of destruction. Virtually invincible, very few have faced this awesome creature and lived to tell the tale."
    },
    "Blue-Winged Crown": {
+      id: "41396436",
       cardType: NORMAL_MONSTER,
       attribute: WIND,
       levelOrSubtype: 4,
@@ -282,6 +317,7 @@ const normalMonsters = {
       text: "Winged Beast – With hair shaped like a crown and a body incased in bluish white flames, this bird is a formidable sight."
    },
    "Bokoichi the Freightening Car": {
+      id: "08715625",
       cardType: NORMAL_MONSTER,
       attribute: DARK,
       levelOrSubtype: 2,
@@ -290,6 +326,7 @@ const normalMonsters = {
       text: "Machine – A freight car that is exclusively for Dekoichi. It can transport anything, but most cargo arrives broken."
    },
    Boneheimer: {
+      id: "98456117",
       cardType: NORMAL_MONSTER,
       attribute: WATER,
       levelOrSubtype: 3,
@@ -298,6 +335,7 @@ const normalMonsters = {
       text: "Aqua – This monster wanders the seas, sucking dry any creatures it may encounter."
    },
    "Bottom Dweller": {
+      id: "81386177",
       cardType: NORMAL_MONSTER,
       attribute: WATER,
       levelOrSubtype: 5,
@@ -306,6 +344,7 @@ const normalMonsters = {
       text: "Fish – This is one sea creature whose wrath is something monsters fear to face."
    },
    Burglar: {
+      id: "06297941",
       cardType: NORMAL_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 3,
@@ -314,6 +353,7 @@ const normalMonsters = {
       text: "Beast – A sly rat. He will come at you with his huge left claw."
    },
    "Celtic Guardian": {
+      id: "91152256",
       cardType: NORMAL_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 4,
@@ -322,6 +362,7 @@ const normalMonsters = {
       text: "Warrior – An elf who learned to wield a sword, he baffles enemies with lightning-swift attacks."
    },
    "Charcoal Inpachi": {
+      id: "13179332",
       cardType: NORMAL_MONSTER,
       attribute: FIRE,
       levelOrSubtype: 1,
@@ -330,6 +371,7 @@ const normalMonsters = {
       text: "Pyro – A wicked wooden spirit that has burned out. The barbecue grilled with this charcoal is so awesome that everybody thinks it's priceless."
    },
    "Chu-Ske the Mouse Fighter": {
+      id: "08508055",
       cardType: NORMAL_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 3,
@@ -338,6 +380,7 @@ const normalMonsters = {
       text: "Beast – A fiery mouse, traveling the world to become the strongest fighter in the world of mice. Be careful not to touch him, or you will get burned."
    },
    "Claw Reacher": {
+      id: "41218256",
       cardType: NORMAL_MONSTER,
       attribute: DARK,
       levelOrSubtype: 3,
@@ -346,6 +389,7 @@ const normalMonsters = {
       text: "Fiend – Stretching arms and razor-sharp claws make this monster a formidable opponent."
    },
    "Clown Zombie": {
+      id: "92667214",
       cardType: NORMAL_MONSTER,
       attribute: DARK,
       levelOrSubtype: 2,
@@ -354,6 +398,7 @@ const normalMonsters = {
       text: "Zombie – A clown revived by the powers of darkenss. Its deadly dance has sent many monster to their graves."
    },
    "Corroding Shark": {
+      id: "34290067",
       cardType: NORMAL_MONSTER,
       attribute: DARK,
       levelOrSubtype: 3,
@@ -362,6 +407,7 @@ const normalMonsters = {
       text: "Zombie – A zombie shark that can deliver its lethal curse with a spell."
    },
    "Cosmo Queen": {
+      id: "38999506",
       cardType: NORMAL_MONSTER,
       attribute: DARK,
       levelOrSubtype: 8,
@@ -370,6 +416,7 @@ const normalMonsters = {
       text: "Spellcaster – Queen of the galaxies and mistress of the stars."
    },
    "Crawling Dragon": {
+      id: "67494157",
       cardType: NORMAL_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 5,
@@ -378,6 +425,7 @@ const normalMonsters = {
       text: "Dragon – This weakened dragon can no longer fly, but it is still a deadly force to be reckoned with."
    },
    "Crawling Dragon #2": {
+      id: "38289717",
       cardType: NORMAL_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 4,
@@ -386,6 +434,7 @@ const normalMonsters = {
       text: "Dinosaur – A powerful dragon with teeth that can grind almost anything to dust."
    },
    "Curse of Dragon": {
+      id: "28279543",
       cardType: NORMAL_MONSTER,
       attribute: DARK,
       levelOrSubtype: 5,
@@ -394,6 +443,7 @@ const normalMonsters = {
       text: "Dragon – A wicked dragon that taps into dark forces to execute a powerful attack."
    },
    "Cyber Falcon": {
+      id: "30655537",
       cardType: NORMAL_MONSTER,
       attribute: WIND,
       levelOrSubtype: 4,
@@ -402,6 +452,7 @@ const normalMonsters = {
       text: "Machine – A jet-powered hawk that travels at the speed of sound."
    },
    "Cyber Soldier of Darkworld": {
+      id: "75559356",
       cardType: NORMAL_MONSTER,
       attribute: DARK,
       levelOrSubtype: 4,
@@ -410,6 +461,7 @@ const normalMonsters = {
       text: "Machine – A mechanical soldier that won't stop attacking until all of its life readings have been extinguished from its sensors."
    },
    "D. Human": {
+      id: "81057959",
       cardType: NORMAL_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 4,
@@ -418,6 +470,7 @@ const normalMonsters = {
       text: "Warrior – Gifted with the power of dragons, this warrior wields a sword created from a dragon's fang."
    },
    "D.D. Trainer": {
+      id: "86498013",
       cardType: NORMAL_MONSTER,
       attribute: DARK,
       levelOrSubtype: 1,
@@ -426,6 +479,7 @@ const normalMonsters = {
       text: "Fiend – A poor goblin that was sucked into a different dimension. However, he's doing his best with his new destiny."
    },
    "Dancing Elf": {
+      id: "59983499",
       cardType: NORMAL_MONSTER,
       attribute: WIND,
       levelOrSubtype: 1,
@@ -434,6 +488,7 @@ const normalMonsters = {
       text: "Fairy – An elf that dances across the sky with wings of razor-sharp blades."
    },
    "Dark Assailant": {
+      id: "41949033",
       cardType: NORMAL_MONSTER,
       attribute: DARK,
       levelOrSubtype: 4,
@@ -442,6 +497,7 @@ const normalMonsters = {
       text: "Zombie – Armed with the Psycho Sword, this sinister assassin rules the bad land."
    },
    "Dark Bat": {
+      id: "67049542",
       cardType: NORMAL_MONSTER,
       attribute: WIND,
       levelOrSubtype: 3,
@@ -450,6 +506,7 @@ const normalMonsters = {
       text: "Winged Beast – Bats from the netherworld that use their hyper senses to detect their enemies."
    },
    "Dark Blade": {
+      id: "11321183",
       cardType: NORMAL_MONSTER,
       attribute: DARK,
       levelOrSubtype: 4,
@@ -458,6 +515,7 @@ const normalMonsters = {
       text: "Warrior – They say he is a dragon-manipulating warrior from the dark world. His attack is tremendous, using his great swords with vicious power."
    },
    "Dark Gray": {
+      id: "09159938",
       cardType: NORMAL_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 3,
@@ -466,6 +524,7 @@ const normalMonsters = {
       text: "Beast – Entirely gray, this beast has rarely been seen by mortal eyes."
    },
    "Dark King of the Abyss": {
+      id: "53375573",
       cardType: NORMAL_MONSTER,
       attribute: DARK,
       levelOrSubtype: 3,
@@ -474,6 +533,7 @@ const normalMonsters = {
       text: "Fiend – It's said that this King of the Netherworld once had the power to rule over the dark."
    },
    "Dark Magician": {
+      id: "46986414",
       cardType: NORMAL_MONSTER,
       attribute: DARK,
       levelOrSubtype: 7,
@@ -482,6 +542,7 @@ const normalMonsters = {
       text: "Spellcaster – The ultimate wizard in terms of attack and defense."
    },
    "Dark Titan of Terror": {
+      id: "89494469",
       cardType: NORMAL_MONSTER,
       attribute: DARK,
       levelOrSubtype: 4,
@@ -490,6 +551,7 @@ const normalMonsters = {
       text: "Fiend – A fiend said to dwell in the world of dreams, it attacks enemies in their sleep."
    },
    "Dark Witch": {
+      id: "35565537",
       cardType: NORMAL_MONSTER,
       attribute: LIGHT,
       levelOrSubtype: 5,
@@ -498,6 +560,7 @@ const normalMonsters = {
       text: "Fairy – A popular creature in mythology that delivers fatal attacks with a sharp spear."
    },
    "Darkfire Soldier #1": {
+      id: "05388481",
       cardType: NORMAL_MONSTER,
       attribute: FIRE,
       levelOrSubtype: 4,
@@ -506,6 +569,7 @@ const normalMonsters = {
       text: "Pyro – An explosive expert from a special elite force."
    },
    "Darkfire Soldier #2": {
+      id: "78861134",
       cardType: NORMAL_MONSTER,
       attribute: FIRE,
       levelOrSubtype: 4,
@@ -514,6 +578,7 @@ const normalMonsters = {
       text: "Pyro – A warrior who gained immeasurable power from the heart of a volcano."
    },
    "Darkworld Thorns": {
+      id: "43500484",
       cardType: NORMAL_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 3,
@@ -522,6 +587,7 @@ const normalMonsters = {
       text: "Plant – A thorny plant found in the darklands that wraps its body around any unwary travelers."
    },
    "Destroyer Golem": {
+      id: "73481154",
       cardType: NORMAL_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 4,
@@ -530,6 +596,7 @@ const normalMonsters = {
       text: "Rock – A golem with a massive right hand for crushing its victims."
    },
    "Dharma Cannon": {
+      id: "96967123",
       cardType: NORMAL_MONSTER,
       attribute: DARK,
       levelOrSubtype: 2,
@@ -538,6 +605,7 @@ const normalMonsters = {
       text: "Machine – A monstrous creature whose body is lined with cannons that never miss their targets."
    },
    "Disk Magician": {
+      id: "76446915",
       cardType: NORMAL_MONSTER,
       attribute: DARK,
       levelOrSubtype: 4,
@@ -546,6 +614,7 @@ const normalMonsters = {
       text: "Machine – This monster hides in a saucer and only appears when executing an attack."
    },
    Dissolverock: {
+      id: "40826495",
       cardType: NORMAL_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 3,
@@ -554,6 +623,7 @@ const normalMonsters = {
       text: "Rock – A monster born in the lava pits, it generates intense heat that can melt away its enemies."
    },
    "Divine Dragon Ragnarok": {
+      id: "62113340",
       cardType: NORMAL_MONSTER,
       attribute: LIGHT,
       levelOrSubtype: 4,
@@ -562,6 +632,7 @@ const normalMonsters = {
       text: "Dragon – A legendary dragon sent by the gods as their instrument. Legends say that if provoked, the whole world will sink beneath the sea."
    },
    Dokuroyaiba: {
+      id: "30325729",
       cardType: NORMAL_MONSTER,
       attribute: FIRE,
       levelOrSubtype: 3,
@@ -570,6 +641,7 @@ const normalMonsters = {
       text: "Fiend – A boomerang with brains that will pursue a target to the ends of the earth."
    },
    "Doma The Angel of Silence": {
+      id: "16972957",
       cardType: NORMAL_MONSTER,
       attribute: DARK,
       levelOrSubtype: 5,
@@ -578,6 +650,7 @@ const normalMonsters = {
       text: "Fairy – This fairy rules over the end of existence."
    },
    "Dragon Zombie": {
+      id: "66672569",
       cardType: NORMAL_MONSTER,
       attribute: DARK,
       levelOrSubtype: 3,
@@ -586,6 +659,7 @@ const normalMonsters = {
       text: "Zombie – A dragon revived by sorcery. Its breath is highly corrosive."
    },
    "Drooling Lizard": {
+      id: "16353197",
       cardType: NORMAL_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 3,
@@ -594,6 +668,7 @@ const normalMonsters = {
       text: "Reptile – A blood-sucking snake in human form that attacks any living being that passes nearby."
    },
    "Earthbound Spirit": {
+      id: "67105242",
       cardType: NORMAL_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 4,
@@ -602,6 +677,7 @@ const normalMonsters = {
       text: "Fiend – A vengeful creature formed by the spirits of fallen warriors, it drags any who dare approach it into the deepest bowels of the earth."
    },
    "Elemental HERO Avian": {
+      id: "21844576",
       cardType: NORMAL_MONSTER,
       attribute: WIND,
       levelOrSubtype: 3,
@@ -610,6 +686,7 @@ const normalMonsters = {
       text: "Warrior – A winged Elemental HERO who wheels through the sky and manipulates the wind. His signature move, Featherbreak, gives villainy a blow from sky-high."
    },
    "Elemental HERO Burstinatrix": {
+      id: "58932615",
       cardType: NORMAL_MONSTER,
       attribute: FIRE,
       levelOrSubtype: 3,
@@ -618,6 +695,7 @@ const normalMonsters = {
       text: "Warrior – A flame manipulator who was the first Elemental HERO woman. Her Burstfire burns away villainy."
    },
    "Elemental HERO Clayman": {
+      id: "84327329",
       cardType: NORMAL_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 4,
@@ -626,6 +704,7 @@ const normalMonsters = {
       text: "Warrior – An Elemental HERO with a clay body built-to-last. He'll preserve his Elemental HERO colleagues at any cost."
    },
    "Elemental HERO Sparkman": {
+      id: "20721928",
       cardType: NORMAL_MONSTER,
       attribute: LIGHT,
       levelOrSubtype: 4,
@@ -634,6 +713,7 @@ const normalMonsters = {
       text: "Warrior – An Elemental HERO and a warrior of light who proficiently wields many kinds of armaments. His Static Shockwave cuts off the path of villainy."
    },
    "Empress Mantis": {
+      id: "58818411",
       cardType: NORMAL_MONSTER,
       attribute: WIND,
       levelOrSubtype: 6,
@@ -642,6 +722,7 @@ const normalMonsters = {
       text: "Insect – Queen of an army of giant mantises whose command moves legions."
    },
    "Enchanting Mermaid": {
+      id: "75376965",
       cardType: NORMAL_MONSTER,
       attribute: WATER,
       levelOrSubtype: 3,
@@ -650,6 +731,7 @@ const normalMonsters = {
       text: "Fish – A beautiful mermaid that lures voyagers to a watery death."
    },
    "Fairy's Gift": {
+      id: "68401546",
       cardType: NORMAL_MONSTER,
       attribute: LIGHT,
       levelOrSubtype: 4,
@@ -658,6 +740,7 @@ const normalMonsters = {
       text: "Spellcaster – This flying monster is known for delivering happiness to all."
    },
    "Faith Bird": {
+      id: "75582395",
       cardType: NORMAL_MONSTER,
       attribute: WIND,
       levelOrSubtype: 4,
@@ -666,6 +749,7 @@ const normalMonsters = {
       text: "Winged Beast – This long-tailed bird blinds its enemies with mystical light."
    },
    "Feral Imp": {
+      id: "41392891",
       cardType: NORMAL_MONSTER,
       attribute: DARK,
       levelOrSubtype: 4,
@@ -674,6 +758,7 @@ const normalMonsters = {
       text: "Fiend – A playful little fiend that lurks in the dark, waiting to attack an unwary enemy."
    },
    "Fiend Reflection #2": {
+      id: "02863439",
       cardType: NORMAL_MONSTER,
       attribute: LIGHT,
       levelOrSubtype: 4,
@@ -682,6 +767,7 @@ const normalMonsters = {
       text: "Winged Beast – A bird-beast that summons reinforcements with a hand mirror."
    },
    "Fiend Scorpion": {
+      id: "26566878",
       cardType: NORMAL_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 2,
@@ -690,6 +776,7 @@ const normalMonsters = {
       text: "Insect – A huge scorpion inhabited by the soul of a fiend. Usually it holds back, but has untapped potential."
    },
    "Fire Kraken": {
+      id: "46534755",
       cardType: NORMAL_MONSTER,
       attribute: FIRE,
       levelOrSubtype: 4,
@@ -698,6 +785,7 @@ const normalMonsters = {
       text: "Aqua – A squid that thrives on fire and heat."
    },
    Firegrass: {
+      id: "53293545",
       cardType: NORMAL_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 2,
@@ -706,6 +794,7 @@ const normalMonsters = {
       text: "Plant – A fire-breathing plant found growing near volcanoes."
    },
    Fireyarou: {
+      id: "71407486",
       cardType: NORMAL_MONSTER,
       attribute: FIRE,
       levelOrSubtype: 4,
@@ -714,6 +803,7 @@ const normalMonsters = {
       text: "Pyro – A malevolent creature wrapped in flames that attacks enemies with intense fire."
    },
    "Flame Cerebrus": {
+      id: "60862676",
       cardType: NORMAL_MONSTER,
       attribute: FIRE,
       levelOrSubtype: 6,
@@ -722,6 +812,7 @@ const normalMonsters = {
       text: 'Pyro – Known to many as the "Burning Executioner", this monster is capable of burning enemies to cinders.'
    },
    "Flame Champion": {
+      id: "42599677",
       cardType: NORMAL_MONSTER,
       attribute: FIRE,
       levelOrSubtype: 5,
@@ -730,6 +821,7 @@ const normalMonsters = {
       text: "Pyro – A warrior protected by a flaming shield that nullifies any attack."
    },
    "Flame Dancer": {
+      id: "12883044",
       cardType: NORMAL_MONSTER,
       attribute: FIRE,
       levelOrSubtype: 2,
@@ -738,6 +830,7 @@ const normalMonsters = {
       text: "Pyro – This monster moves while swinging its burning rope."
    },
    "Flame Manipulator": {
+      id: "34460851",
       cardType: NORMAL_MONSTER,
       attribute: FIRE,
       levelOrSubtype: 3,
@@ -746,6 +839,7 @@ const normalMonsters = {
       text: 'Spellcaster – This Spellcaster attacks enemies with fire-related spells such as "Sea of Flames" and "Wall of Fire".'
    },
    "Flying Fish": {
+      id: "31987274",
       cardType: NORMAL_MONSTER,
       attribute: WIND,
       levelOrSubtype: 4,
@@ -754,6 +848,7 @@ const normalMonsters = {
       text: "Fish – Three wishes are granted to those fortunate enough to see this monster in flight."
    },
    "Flying Kamakiri #2": {
+      id: "03134241",
       cardType: NORMAL_MONSTER,
       attribute: WIND,
       levelOrSubtype: 4,
@@ -762,6 +857,7 @@ const normalMonsters = {
       text: "Insect – A flying mantis that feeds primarily on insects."
    },
    "Flying Penguin": {
+      id: "05628232",
       cardType: NORMAL_MONSTER,
       attribute: WATER,
       levelOrSubtype: 4,
@@ -770,6 +866,7 @@ const normalMonsters = {
       text: "Aqua – A very rare penguin that takes to the air with ears shaped like wings."
    },
    "Frenzied Panda": {
+      id: "98818516",
       cardType: NORMAL_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 4,
@@ -778,6 +875,7 @@ const normalMonsters = {
       text: "Beast – A savage beast that carries a big bamboo stick for beating down its enemies."
    },
    "Gadget Soldier": {
+      id: "86281779",
       cardType: NORMAL_MONSTER,
       attribute: FIRE,
       levelOrSubtype: 6,
@@ -786,6 +884,7 @@ const normalMonsters = {
       text: "Machine – A rust-free machine warrior born to battle."
    },
    Gagagigo: {
+      id: "49003308",
       cardType: NORMAL_MONSTER,
       attribute: WATER,
       levelOrSubtype: 4,
@@ -794,6 +893,7 @@ const normalMonsters = {
       text: "Reptile – This young evildoer used to have an evil heart, but by meeting a special person, he discovered justice."
    },
    "Gaia The Fierce Knight": {
+      id: "06368038",
       cardType: NORMAL_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 7,
@@ -802,6 +902,7 @@ const normalMonsters = {
       text: "Warrior – A knight whose horse travels faster than the wind. His battle-charge is a force to be reckoned with."
    },
    "Gamma The Magnet Warrior": {
+      id: "11549357",
       cardType: NORMAL_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 4,
@@ -810,6 +911,7 @@ const normalMonsters = {
       text: "Rock – Alpha, Beta, and Gamma meld as one to form a powerful monster."
    },
    "Garnecia Elefantis": {
+      id: "49888191",
       cardType: NORMAL_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 7,
@@ -818,6 +920,7 @@ const normalMonsters = {
       text: "Beast-Warrior – A monster so heavy that each step rocks the earth."
    },
    Garoozis: {
+      id: "14977074",
       cardType: NORMAL_MONSTER,
       attribute: FIRE,
       levelOrSubtype: 5,
@@ -826,6 +929,7 @@ const normalMonsters = {
       text: "Beast-Warrior – An axe-swinging beast-warrior with the head of a dragon."
    },
    "Gazelle the King of Mythical Beasts": {
+      id: "05818798",
       cardType: NORMAL_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 4,
@@ -834,6 +938,7 @@ const normalMonsters = {
       text: "Beast – This monster moves so fast that it looks like an illusion to mortal eyes."
    },
    "Gemini Elf": {
+      id: "69140098",
       cardType: NORMAL_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 4,
@@ -842,6 +947,7 @@ const normalMonsters = {
       text: "Spellcaster – Elf twins that alternate their attacks."
    },
    "Giant Flea": {
+      id: "41762634",
       cardType: NORMAL_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 4,
@@ -850,6 +956,7 @@ const normalMonsters = {
       text: "Insect – A massive flea that feeds on the blood of its enemies."
    },
    "Giant Red Seasnake": {
+      id: "58831685",
       cardType: NORMAL_MONSTER,
       attribute: WATER,
       levelOrSubtype: 4,
@@ -858,6 +965,7 @@ const normalMonsters = {
       text: "Aqua – A sea-dwelling snake that attacks passing enemies with its sharp teeth."
    },
    "Giant Soldier of Stone": {
+      id: "13039848",
       cardType: NORMAL_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 3,
@@ -866,6 +974,7 @@ const normalMonsters = {
       text: "Rock – A giant warrior made of stone. A punch from this creature has earth-shaking results."
    },
    "Giant Turtle Who Feeds on Flames": {
+      id: "96981563",
       cardType: NORMAL_MONSTER,
       attribute: WATER,
       levelOrSubtype: 5,
@@ -874,6 +983,7 @@ const normalMonsters = {
       text: "Aqua – A crimson-shelled tortoise that feeds on flames."
    },
    "Giga Gagagigo": {
+      id: "43793530",
       cardType: NORMAL_MONSTER,
       attribute: WATER,
       levelOrSubtype: 5,
@@ -882,6 +992,7 @@ const normalMonsters = {
       text: "Reptile – In order to fight tremendous evil, he gained formidable power through body reconstruction, but lost his heart and his redemption."
    },
    "Giga-Tech Wolf": {
+      id: "08471389",
       cardType: NORMAL_MONSTER,
       attribute: FIRE,
       levelOrSubtype: 4,
@@ -890,6 +1001,7 @@ const normalMonsters = {
       text: "Machine – An iron wolf with razor-sharp fangs that can penetrate any armor."
    },
    Gigobyte: {
+      id: "53776525",
       cardType: NORMAL_MONSTER,
       attribute: WATER,
       levelOrSubtype: 1,
@@ -898,6 +1010,7 @@ const normalMonsters = {
       text: "Reptile – He has a tranquil soul, but carries a destiny that one day his heart shall be tainted by evil...."
    },
    "Girochin Kuwagata": {
+      id: "84620194",
       cardType: NORMAL_MONSTER,
       attribute: WIND,
       levelOrSubtype: 4,
@@ -906,6 +1019,7 @@ const normalMonsters = {
       text: "Insect – Despite its small size, this monster has powerful jaws that can rip metal to shreds."
    },
    "Goblin Calligrapher": {
+      id: "12057781",
       cardType: NORMAL_MONSTER,
       attribute: DARK,
       levelOrSubtype: 1,
@@ -914,6 +1028,7 @@ const normalMonsters = {
       text: 'Fiend – A Goblin who devotes himself to mastering perfect calligraphy of the word "False". He gives his all to each stroke.'
    },
    "Gogiga Gagagigo": {
+      id: "39674352",
       cardType: NORMAL_MONSTER,
       attribute: WATER,
       levelOrSubtype: 8,
@@ -922,6 +1037,7 @@ const normalMonsters = {
       text: "Reptile – His soul long since collapsed, his body recklessly continues onward, driven by a lust for more power. He no longer resembles his former self...."
    },
    Gradius: {
+      id: "10992251",
       cardType: NORMAL_MONSTER,
       attribute: LIGHT,
       levelOrSubtype: 4,
@@ -930,6 +1046,7 @@ const normalMonsters = {
       text: "Machine – A high-performance jet fighter with power capsules for variable attack capabilities."
    },
    "Grand Tiki Elder": {
+      id: "13676474",
       cardType: NORMAL_MONSTER,
       attribute: DARK,
       levelOrSubtype: 4,
@@ -938,6 +1055,7 @@ const normalMonsters = {
       text: "Fiend – A masked monster that wields the most deadly of curses."
    },
    "Great Angus": {
+      id: "11813953",
       cardType: NORMAL_MONSTER,
       attribute: FIRE,
       levelOrSubtype: 4,
@@ -946,6 +1064,7 @@ const normalMonsters = {
       text: "Beast – A very violent beast, it is always berserk. People say that they have never seen it silent."
    },
    "Great White": {
+      id: "13429800",
       cardType: NORMAL_MONSTER,
       attribute: WATER,
       levelOrSubtype: 4,
@@ -954,6 +1073,7 @@ const normalMonsters = {
       text: "Fish – A giant white shark with razor-sharp teeth."
    },
    "Green Phantom King": {
+      id: "22910685",
       cardType: NORMAL_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 3,
@@ -962,6 +1082,7 @@ const normalMonsters = {
       text: "Plant – This youthful king of the forest lives in a green world, abundant with trees and wildlife."
    },
    "Ground Attacker Bugroth": {
+      id: "58314394",
       cardType: NORMAL_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 4,
@@ -970,6 +1091,7 @@ const normalMonsters = {
       text: "Machine – A surface battle robot that was once used for sea warfare."
    },
    "Guardian of the Labyrinth": {
+      id: "89272878",
       cardType: NORMAL_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 4,
@@ -978,6 +1100,7 @@ const normalMonsters = {
       text: "Warrior – A monster that guards the entrance to the Netherworld."
    },
    "Guardian of the Throne Room": {
+      id: "47879985",
       cardType: NORMAL_MONSTER,
       attribute: LIGHT,
       levelOrSubtype: 4,
@@ -986,6 +1109,7 @@ const normalMonsters = {
       text: "Machine – A robot guard built to guard throne rooms, it is armed with homing missiles."
    },
    "Gyakutenno Megami": {
+      id: "31122090",
       cardType: NORMAL_MONSTER,
       attribute: LIGHT,
       levelOrSubtype: 6,
@@ -994,6 +1118,7 @@ const normalMonsters = {
       text: "Fairy – This fairy uses her mystical power to protect the weak and provide spiritual support."
    },
    "Hard Armor": {
+      id: "20060230",
       cardType: NORMAL_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 3,
@@ -1002,6 +1127,7 @@ const normalMonsters = {
       text: "Warrior – A living suit of armor that attacks enemies with a bone-jarring tackle."
    },
    "Harpie Girl": {
+      id: "34100324",
       cardType: NORMAL_MONSTER,
       attribute: WIND,
       levelOrSubtype: 2,
@@ -1010,6 +1136,7 @@ const normalMonsters = {
       text: "Winged Beast – A Harpie chick who aspires to flit about beautifully and gorgeously, but attack sharply."
    },
    "Harpie Lady": {
+      id: "76812113",
       cardType: NORMAL_MONSTER,
       attribute: WIND,
       levelOrSubtype: 4,
@@ -1018,6 +1145,7 @@ const normalMonsters = {
       text: "Winged Beast – This human-shaped animal with wings is beautiful to watch but deadly in battle."
    },
    "Headless Knight": {
+      id: "05434080",
       cardType: NORMAL_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 4,
@@ -1026,6 +1154,7 @@ const normalMonsters = {
       text: "Fiend – A haunted spirit of a falsely accused knight who wanders in search of truth and justice."
    },
    "Hercules Beetle": {
+      id: "52584282",
       cardType: NORMAL_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 5,
@@ -1034,6 +1163,7 @@ const normalMonsters = {
       text: "Insect – A massive beetle with a tough carapace and a dangerous horn."
    },
    Hibikime: {
+      id: "64501875",
       cardType: NORMAL_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 4,
@@ -1042,6 +1172,7 @@ const normalMonsters = {
       text: "Warrior – Confuses enemies with a noise that is harsh to the ears."
    },
    "High Tide Gyojin": {
+      id: "54579801",
       cardType: NORMAL_MONSTER,
       attribute: WATER,
       levelOrSubtype: 4,
@@ -1050,6 +1181,7 @@ const normalMonsters = {
       text: "Aqua – A very agile half-fish warrior known for its relentless attacks."
    },
    "Hinotama Soul": {
+      id: "96851799",
       cardType: NORMAL_MONSTER,
       attribute: FIRE,
       levelOrSubtype: 2,
@@ -1058,6 +1190,7 @@ const normalMonsters = {
       text: "Pyro – An intensely hot flame creature that rams anything standing in its way."
    },
    "Hitotsu-Me Giant": {
+      id: "76184692",
       cardType: NORMAL_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 4,
@@ -1066,6 +1199,7 @@ const normalMonsters = {
       text: "Beast-Warrior – A one-eyed behemoth with thick, powerful arms made for delivering punishing blows."
    },
    "Humanoid Slime": {
+      id: "46821314",
       cardType: NORMAL_MONSTER,
       attribute: WATER,
       levelOrSubtype: 4,
@@ -1074,6 +1208,7 @@ const normalMonsters = {
       text: "Aqua – This slime apparently has some human genes in its genetic makeup."
    },
    "Hunter Spider": {
+      id: "80141480",
       cardType: NORMAL_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 5,
@@ -1082,6 +1217,7 @@ const normalMonsters = {
       text: "Insect – This monster feeds on whatever it catches in its web."
    },
    Hyosube: {
+      id: "02118022",
       cardType: NORMAL_MONSTER,
       attribute: WATER,
       levelOrSubtype: 4,
@@ -1090,6 +1226,7 @@ const normalMonsters = {
       text: "Aqua – This amphibian is strong on the attack, but leaves much to be desired when defending."
    },
    Hyozanryu: {
+      id: "62397231",
       cardType: NORMAL_MONSTER,
       attribute: LIGHT,
       levelOrSubtype: 7,
@@ -1098,6 +1235,7 @@ const normalMonsters = {
       text: "Dragon – A dragon created from a massive diamond that sparkles with blinding light."
    },
    "Illusionist Faceless Mage": {
+      id: "28546905",
       cardType: NORMAL_MONSTER,
       attribute: DARK,
       levelOrSubtype: 5,
@@ -1106,6 +1244,7 @@ const normalMonsters = {
       text: "Spellcaster – Manipulates enemy attacks with the power of illusion."
    },
    Inpachi: {
+      id: "97923414",
       cardType: NORMAL_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 4,
@@ -1114,6 +1253,7 @@ const normalMonsters = {
       text: "Machine – A log that attacks lost travelers in the forest. Originally a big tree, it was cut down and possessed by a wicked spirit."
    },
    "Insect Knight": {
+      id: "35052053",
       cardType: NORMAL_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 4,
@@ -1122,6 +1262,7 @@ const normalMonsters = {
       text: "Insect – Of all Insect fighters, he is the paragon of the Indestructible Insect Invaders, which only the elite of the elite can join. We can no longer ignore their unmatched battle prowess."
    },
    "Island Turtle": {
+      id: "04042268",
       cardType: NORMAL_MONSTER,
       attribute: WATER,
       levelOrSubtype: 4,
@@ -1130,6 +1271,7 @@ const normalMonsters = {
       text: "Aqua – A huge turtle that is often mistaken for an island."
    },
    Jellyfish: {
+      id: "14851496",
       cardType: NORMAL_MONSTER,
       attribute: WATER,
       levelOrSubtype: 4,
@@ -1138,6 +1280,7 @@ const normalMonsters = {
       text: "Aqua – An almost invisible, semi-transparent jellyfish that drifts in the sea."
    },
    "Judge Man": {
+      id: "30113682",
       cardType: NORMAL_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 6,
@@ -1146,6 +1289,7 @@ const normalMonsters = {
       text: "Warrior – This club-wielding warrior battles to the end and will never surrender."
    },
    Kabazauls: {
+      id: "51934376",
       cardType: NORMAL_MONSTER,
       attribute: WATER,
       levelOrSubtype: 4,
@@ -1154,6 +1298,7 @@ const normalMonsters = {
       text: "Dinosaur – A huge monster in the shape of a hippopotamus. The sneezing from his gigantic body is so fierce that people mistake it for a hurricane."
    },
    "Kagemusha of the Blue Flame": {
+      id: "15401633",
       cardType: NORMAL_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 2,
@@ -1162,6 +1307,7 @@ const normalMonsters = {
       text: "Warrior – Serving as a double for the Ruler of the Blue Flame, he's a master swordsman that wields a fine blade."
    },
    "Killer Needle": {
+      id: "88979991",
       cardType: NORMAL_MONSTER,
       attribute: WIND,
       levelOrSubtype: 4,
@@ -1170,6 +1316,7 @@ const normalMonsters = {
       text: "Insect – A huge bee with exceptional strength that's particularly dangerous in a swarm."
    },
    "King Fog": {
+      id: "84686841",
       cardType: NORMAL_MONSTER,
       attribute: DARK,
       levelOrSubtype: 3,
@@ -1178,6 +1325,7 @@ const normalMonsters = {
       text: "Fiend – A fiend that dwells in a blinding curtain of smoke."
    },
    "King of Yamimakai": {
+      id: "69455834",
       cardType: NORMAL_MONSTER,
       attribute: DARK,
       levelOrSubtype: 5,
@@ -1186,6 +1334,7 @@ const normalMonsters = {
       text: "Fiend – Wields the power of darkness to destroy its enemies."
    },
    Kojikocy: {
+      id: "01184620",
       cardType: NORMAL_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 4,
@@ -1194,6 +1343,7 @@ const normalMonsters = {
       text: "Warrior – A man-hunter with powerful arms that can crush boulders"
    },
    "Koumori Dragon": {
+      id: "67724379",
       cardType: NORMAL_MONSTER,
       attribute: DARK,
       levelOrSubtype: 4,
@@ -1202,6 +1352,7 @@ const normalMonsters = {
       text: "Dragon – A vicious, fire-breathing dragon whose wicked flame corrupts the souls of its victims."
    },
    Kozaky: {
+      id: "99171160",
       cardType: NORMAL_MONSTER,
       attribute: DARK,
       levelOrSubtype: 1,
@@ -1210,6 +1361,7 @@ const normalMonsters = {
       text: "Fiend – A workaholic fiend who devotes everything to his research into the languages of Dark World. His mind has collapsed because of working too hard."
    },
    Kumootoko: {
+      id: "56283725",
       cardType: NORMAL_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 3,
@@ -1218,6 +1370,7 @@ const normalMonsters = {
       text: "Insect – A massive, intelligent spider that traps enemies with webbing."
    },
    Kurama: {
+      id: "85705804",
       cardType: NORMAL_MONSTER,
       attribute: WIND,
       levelOrSubtype: 3,
@@ -1226,6 +1379,7 @@ const normalMonsters = {
       text: "Winged Beast – A vicious bird that attacks from the skies with its whip-like tail."
    },
    "Kuwagata α": {
+      id: "60802233",
       cardType: NORMAL_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 4,
@@ -1234,6 +1388,7 @@ const normalMonsters = {
       text: "Insect – A very vicious stag beetle that goes for the head."
    },
    "La Jinn the Mystical Genie of the Lamp": {
+      id: "97590747",
       cardType: NORMAL_MONSTER,
       attribute: DARK,
       levelOrSubtype: 4,
@@ -1242,6 +1397,7 @@ const normalMonsters = {
       text: "Fiend – A genie of the lamp that is at the beck and call of its master."
    },
    "Labyrinth Wall": {
+      id: "67284908",
       cardType: NORMAL_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 5,
@@ -1250,6 +1406,7 @@ const normalMonsters = {
       text: "Rock – These walls form a labyrinth with no exit for enemies."
    },
    "Lady of Faith": {
+      id: "17358176",
       cardType: NORMAL_MONSTER,
       attribute: LIGHT,
       levelOrSubtype: 3,
@@ -1258,6 +1415,7 @@ const normalMonsters = {
       text: "Spellcaster – Soothes the souls of others by chanting a mysterious spell."
    },
    Larvas: {
+      id: "94675535",
       cardType: NORMAL_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 3,
@@ -1266,6 +1424,7 @@ const normalMonsters = {
       text: "Beast – A fast-moving, bird-like creature that strangles opposing monsters with its long, thin arms."
    },
    "Launcher Spider": {
+      id: "87322377",
       cardType: NORMAL_MONSTER,
       attribute: FIRE,
       levelOrSubtype: 7,
@@ -1274,6 +1433,7 @@ const normalMonsters = {
       text: "Machine – A mechanical spider with rocket launchers capable of random fire."
    },
    "Left Arm of the Forbidden One": {
+      id: "07902349",
       cardType: NORMAL_MONSTER,
       attribute: DARK,
       levelOrSubtype: 1,
@@ -1282,6 +1442,7 @@ const normalMonsters = {
       text: "Spellcaster – A forbidden left arm sealed by magic. Whosoever breaks this seal will know infinite power."
    },
    "Left Leg of the Forbidden One": {
+      id: "44519536",
       cardType: NORMAL_MONSTER,
       attribute: DARK,
       levelOrSubtype: 1,
@@ -1290,6 +1451,7 @@ const normalMonsters = {
       text: "Spellcaster – A forbidden left leg sealed by magic. Whosoever breaks this seal will know infinite power."
    },
    Leogun: {
+      id: "10538007",
       cardType: NORMAL_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 5,
@@ -1298,6 +1460,7 @@ const normalMonsters = {
       text: "Beast – Huge monster with a lion's mane similar to the King of Beasts."
    },
    "Lesser Dragon": {
+      id: "55444629",
       cardType: NORMAL_MONSTER,
       attribute: WIND,
       levelOrSubtype: 4,
@@ -1306,6 +1469,7 @@ const normalMonsters = {
       text: "Dragon – A minor dragon incapable of breathing fire."
    },
    "Lightning Conger": {
+      id: "27671321",
       cardType: NORMAL_MONSTER,
       attribute: WATER,
       levelOrSubtype: 3,
@@ -1314,6 +1478,7 @@ const normalMonsters = {
       text: "Thunder – This massive eel generates huge charges of electricity and unleashes them as thunderbolts."
    },
    "Liquid Beast": {
+      id: "93108297",
       cardType: NORMAL_MONSTER,
       attribute: WATER,
       levelOrSubtype: 3,
@@ -1322,6 +1487,7 @@ const normalMonsters = {
       text: "Aqua – A liquid life form that thrives on water."
    },
    "Lizard Soldier": {
+      id: "20831168",
       cardType: NORMAL_MONSTER,
       attribute: WIND,
       levelOrSubtype: 3,
@@ -1330,6 +1496,7 @@ const normalMonsters = {
       text: "Dragon – A beast soldier derived from dragons, it is small for a Dragon-Type. Moving very quickly, this monster is an excellent strategist."
    },
    "Lord of the Lamp": {
+      id: "99510761",
       cardType: NORMAL_MONSTER,
       attribute: DARK,
       levelOrSubtype: 4,
@@ -1338,6 +1505,7 @@ const normalMonsters = {
       text: "Fiend – This spirit emerges from the mystic lamp and obeys the wishes of its summoner."
    },
    "Luster Dragon": {
+      id: "11091375",
       cardType: NORMAL_MONSTER,
       attribute: WIND,
       levelOrSubtype: 4,
@@ -1346,6 +1514,7 @@ const normalMonsters = {
       text: "Dragon – A very beautiful dragon covered with sapphire. It does not like fights, but has incredibly high attack power."
    },
    "Luster Dragon #2": {
+      id: "17658803",
       cardType: NORMAL_MONSTER,
       attribute: WIND,
       levelOrSubtype: 6,
@@ -1354,6 +1523,7 @@ const normalMonsters = {
       text: "Dragon – This dragon feeds on emerald. Enchanted by this monster even when attacked, few people live to tell of its beauty."
    },
    "M-Warrior #1": {
+      id: "56342351",
       cardType: NORMAL_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 3,
@@ -1362,6 +1532,7 @@ const normalMonsters = {
       text: "Warrior – Specializing in combination attacks, this warrior uses magnetism to block an enemy's escape."
    },
    "M-Warrior #2": {
+      id: "92731455",
       cardType: NORMAL_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 3,
@@ -1370,6 +1541,7 @@ const normalMonsters = {
       text: "Warrior – Specializing in combination attacks, this warrior is equipped with a tough, magnetically coated armor."
    },
    "Mad Dog of Darkness": {
+      id: "79182538",
       cardType: NORMAL_MONSTER,
       attribute: DARK,
       levelOrSubtype: 4,
@@ -1378,6 +1550,7 @@ const normalMonsters = {
       text: "Beast – He used to be a normal dog who played around in a park, but was corrupted by the powers of darkness."
    },
    "Magical Ghost": {
+      id: "46474915",
       cardType: NORMAL_MONSTER,
       attribute: DARK,
       levelOrSubtype: 4,
@@ -1386,6 +1559,7 @@ const normalMonsters = {
       text: "Zombie – This creature casts a spell of terror and confusion just before attacking its enemies."
    },
    "Maiden of the Moonlight": {
+      id: "79629370",
       cardType: NORMAL_MONSTER,
       attribute: LIGHT,
       levelOrSubtype: 4,
@@ -1394,6 +1568,7 @@ const normalMonsters = {
       text: "Spellcaster – A sorcerer blessed by lunar light with powers far beyond mortal comprehension."
    },
    "Mammoth Graveyard": {
+      id: "40374923",
       cardType: NORMAL_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 3,
@@ -1402,6 +1577,7 @@ const normalMonsters = {
       text: "Dinosaur – A mammoth that protects the graves of its pack and is absolutely merciless when facing grave-robbers."
    },
    "Man Eater": {
+      id: "93553943",
       cardType: NORMAL_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 2,
@@ -1410,6 +1586,7 @@ const normalMonsters = {
       text: "Plant – Man-eating plant with poison feelers for attacking enemies."
    },
    "Man-Eating Treasure Chest": {
+      id: "13723605",
       cardType: NORMAL_MONSTER,
       attribute: DARK,
       levelOrSubtype: 4,
@@ -1418,6 +1595,7 @@ const normalMonsters = {
       text: "Fiend – A monster disguised as a treasure chest that is known to attack the unwary adventurer."
    },
    "Masaki the Legendary Swordsman": {
+      id: "44287299",
       cardType: NORMAL_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 4,
@@ -1426,6 +1604,7 @@ const normalMonsters = {
       text: "Warrior – Legendary swordmaster Masaki is a veteran of over 100 battles."
    },
    "Master & Expert": {
+      id: "75499502",
       cardType: NORMAL_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 4,
@@ -1434,6 +1613,7 @@ const normalMonsters = {
       text: "Beast – A deadly duo consisting of a beast master and its loyal servant."
    },
    "Master Kyonshee": {
+      id: "24530661",
       cardType: NORMAL_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 4,
@@ -1442,6 +1622,7 @@ const normalMonsters = {
       text: "Zombie – A wandering Kyonshee searching for a strong rival to defeat. They say he was known as the master of all martial arts."
    },
    "Mechanical Snail": {
+      id: "34442949",
       cardType: NORMAL_MONSTER,
       attribute: DARK,
       levelOrSubtype: 3,
@@ -1450,6 +1631,7 @@ const normalMonsters = {
       text: "Machine – A cyborg snail that still travels at a slow place."
    },
    Mechanicalchaser: {
+      id: "07359741",
       cardType: NORMAL_MONSTER,
       attribute: DARK,
       levelOrSubtype: 4,
@@ -1458,6 +1640,7 @@ const normalMonsters = {
       text: "Machine – A hunter that relentlessly pursues its target by order of the Machine King."
    },
    "Meda Bat": {
+      id: "76211194",
       cardType: NORMAL_MONSTER,
       attribute: DARK,
       levelOrSubtype: 2,
@@ -1466,6 +1649,7 @@ const normalMonsters = {
       text: 'Fiend – An eyeball fiend created by a servant of the wicked, it uses "Dark Bombs" to blow away its enemies.'
    },
    "Mega Thunderball": {
+      id: "21817254",
       cardType: NORMAL_MONSTER,
       attribute: WIND,
       levelOrSubtype: 2,
@@ -1474,6 +1658,7 @@ const normalMonsters = {
       text: "Thunder – Rolls along the ground releasing bolts of electricity to attack its enemies."
    },
    "Megasonic Eye": {
+      id: "07562372",
       cardType: NORMAL_MONSTER,
       attribute: DARK,
       levelOrSubtype: 5,
@@ -1482,6 +1667,7 @@ const normalMonsters = {
       text: "Machine – Made of mysterious metal, this monster is a doomsday machine from the edge of the universe."
    },
    "Melchid the Four-Face Beast": {
+      id: "86569121",
       cardType: NORMAL_MONSTER,
       attribute: DARK,
       levelOrSubtype: 4,
@@ -1490,6 +1676,7 @@ const normalMonsters = {
       text: "Fiend – This monster has four different masks for four different attacks."
    },
    "Metal Armored Bug": {
+      id: "65957473",
       cardType: NORMAL_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 8,
@@ -1498,6 +1685,7 @@ const normalMonsters = {
       text: "Insect – A gigantic insect-like creature covered by thick armor. Everything in his path is destroyed."
    },
    "Metal Fish": {
+      id: "55998462",
       cardType: NORMAL_MONSTER,
       attribute: WATER,
       levelOrSubtype: 5,
@@ -1506,6 +1694,7 @@ const normalMonsters = {
       text: "Machine – A metal fish with a razor-sharp caudal fin."
    },
    "Mighty Guard": {
+      id: "62327910",
       cardType: NORMAL_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 4,
@@ -1514,6 +1703,7 @@ const normalMonsters = {
       text: "Machine – A machine soldier that was developed as a guard. It is made of rust-proof metal."
    },
    Mikazukinoyaiba: {
+      id: "38277918",
       cardType: NORMAL_MONSTER,
       attribute: DARK,
       levelOrSubtype: 7,
@@ -1522,6 +1712,7 @@ const normalMonsters = {
       text: "Dragon – A dragon warrior of the moon armed with a crescent sword."
    },
    "Millennium Shield": {
+      id: "32012841",
       cardType: NORMAL_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 5,
@@ -1530,6 +1721,7 @@ const normalMonsters = {
       text: "Warrior – A Millennium item, it's rumored to block any strong attack."
    },
    Misairuzame: {
+      id: "33178416",
       cardType: NORMAL_MONSTER,
       attribute: WATER,
       levelOrSubtype: 5,
@@ -1538,6 +1730,7 @@ const normalMonsters = {
       text: "Fish – A missile-launching fish protected by deadly spikes."
    },
    "Mokey Mokey": {
+      id: "27288416",
       cardType: NORMAL_MONSTER,
       attribute: LIGHT,
       levelOrSubtype: 1,
@@ -1546,6 +1739,7 @@ const normalMonsters = {
       text: "Fairy – An outcast angel. Nobody knows what he is thinking at all. Sometimes he gets mad and that is dreadful."
    },
    "Molten Behemoth": {
+      id: "17192817",
       cardType: NORMAL_MONSTER,
       attribute: FIRE,
       levelOrSubtype: 5,
@@ -1554,6 +1748,7 @@ const normalMonsters = {
       text: "Pyro – A giant born from magma, it attacks with a magma punch."
    },
    "Monster Egg": {
+      id: "36121917",
       cardType: NORMAL_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 3,
@@ -1562,6 +1757,7 @@ const normalMonsters = {
       text: "Warrior – A warrior hidden within an egg that attacks enemies by flinging eggshells."
    },
    Morinphen: {
+      id: "55784832",
       cardType: NORMAL_MONSTER,
       attribute: DARK,
       levelOrSubtype: 5,
@@ -1570,6 +1766,7 @@ const normalMonsters = {
       text: "Fiend – A strange fiend with long arms and razor sharp talons."
    },
    "Mr. Volcano": {
+      id: "31477025",
       cardType: NORMAL_MONSTER,
       attribute: FIRE,
       levelOrSubtype: 5,
@@ -1578,6 +1775,7 @@ const normalMonsters = {
       text: "Pyro – This seemingly mild-mannered creature has an extremely volatile temper."
    },
    "Mystic Clown": {
+      id: "47060154",
       cardType: NORMAL_MONSTER,
       attribute: DARK,
       levelOrSubtype: 4,
@@ -1586,6 +1784,7 @@ const normalMonsters = {
       text: "Fiend – Nothing can stop the mad attack of this powerful creature."
    },
    "Mystic Horseman": {
+      id: "68516705",
       cardType: NORMAL_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 4,
@@ -1594,6 +1793,7 @@ const normalMonsters = {
       text: "Beast – Half man and half horse, this monster is known for its extreme speed."
    },
    "Mystical Elf": {
+      id: "15025844",
       cardType: NORMAL_MONSTER,
       attribute: LIGHT,
       levelOrSubtype: 4,
@@ -1602,6 +1802,7 @@ const normalMonsters = {
       text: "Spellcaster – A delicate elf that lacks offense, but has a terrific defense backed by mystical power."
    },
    "Mystical Sheep #2": {
+      id: "83464209",
       cardType: NORMAL_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 3,
@@ -1610,6 +1811,7 @@ const normalMonsters = {
       text: "Beast – A monstrous sheep with a long tail for hypnotizing enemies."
    },
    "Mystical Shine Ball": {
+      id: "39552864",
       cardType: NORMAL_MONSTER,
       attribute: LIGHT,
       levelOrSubtype: 2,
@@ -1618,6 +1820,7 @@ const normalMonsters = {
       text: "Fairy – A soul of light covered by mystical shine. When you see its beautiful shape, your dream will come true."
    },
    "Nekogal #1": {
+      id: "01761063",
       cardType: NORMAL_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 3,
@@ -1626,6 +1829,7 @@ const normalMonsters = {
       text: "Beast – A pussy-fairy. Contrary to her lovely beauty, she claws on her enemies."
    },
    Nemuriko: {
+      id: "90963488",
       cardType: NORMAL_MONSTER,
       attribute: DARK,
       levelOrSubtype: 3,
@@ -1634,6 +1838,7 @@ const normalMonsters = {
       text: "Spellcaster – A child-like creature that controls a sleep fiend to beckon enemies into eternal slumber."
    },
    "Neo Aqua Madoor": {
+      id: "49563947",
       cardType: NORMAL_MONSTER,
       attribute: WATER,
       levelOrSubtype: 6,
@@ -1642,6 +1847,7 @@ const normalMonsters = {
       text: "Spellcaster – The true nature of this wizard, who rules all water. It defends itself with a vast, impenetrable wall of ice."
    },
    "Neo Bug": {
+      id: "16587243",
       cardType: NORMAL_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 4,
@@ -1650,6 +1856,7 @@ const normalMonsters = {
       text: "Insect – A huge bug-like monster said to come from another planet. It gathers in swarms."
    },
    "Neo the Magic Swordsman": {
+      id: "50930991",
       cardType: NORMAL_MONSTER,
       attribute: LIGHT,
       levelOrSubtype: 4,
@@ -1658,6 +1865,7 @@ const normalMonsters = {
       text: "Spellcaster – A dimensional drifter who not only practices sorcery, but is also a sword and martial arts master."
    },
    "Nin-Ken Dog": {
+      id: "11987744",
       cardType: NORMAL_MONSTER,
       attribute: WIND,
       levelOrSubtype: 4,
@@ -1666,6 +1874,7 @@ const normalMonsters = {
       text: "Beast-Warrior – A Ninja dog who has mastered extreme Ninjutsu. Through hard training, it learned the technique to metamorphose into a human being."
    },
    Niwatori: {
+      id: "07805359",
       cardType: NORMAL_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 3,
@@ -1674,6 +1883,7 @@ const normalMonsters = {
       text: "Winged Beast – Swallows enemies whole and uses their essence as energy."
    },
    Octoberser: {
+      id: "74637266",
       cardType: NORMAL_MONSTER,
       attribute: WATER,
       levelOrSubtype: 5,
@@ -1682,6 +1892,7 @@ const normalMonsters = {
       text: "Aqua – With the head of a fish and the legs of an octopus, this strange creature attacks enemies by flinging spears."
    },
    Ocubeam: {
+      id: "86088138",
       cardType: NORMAL_MONSTER,
       attribute: LIGHT,
       levelOrSubtype: 5,
@@ -1690,6 +1901,7 @@ const normalMonsters = {
       text: "Fairy – Frightening in appearance, this creature uses its large eyes and ears to keep track of any movement."
    },
    "Ogre of the Black Shadow": {
+      id: "45121025",
       cardType: NORMAL_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 4,
@@ -1698,6 +1910,7 @@ const normalMonsters = {
       text: "Beast-Warrior – An ogre possessed by the powers of the dark. Few can withstand its rapid charge."
    },
    "Ojama Black": {
+      id: "79335209",
       cardType: NORMAL_MONSTER,
       attribute: LIGHT,
       levelOrSubtype: 2,
@@ -1706,6 +1919,7 @@ const normalMonsters = {
       text: "Beast – He's one of the Ojama Trio. It's said that he butts in by any means necessary. It's also said that when the three are together, something happens."
    },
    "Ojama Green": {
+      id: "12482652",
       cardType: NORMAL_MONSTER,
       attribute: LIGHT,
       levelOrSubtype: 2,
@@ -1714,6 +1928,7 @@ const normalMonsters = {
       text: "Beast – He's one of the Ojama Trio. It's said that he butts in by any means necessary. It's also said that when the three are together, something happens."
    },
    "Ojama Yellow": {
+      id: "42941100",
       cardType: NORMAL_MONSTER,
       attribute: LIGHT,
       levelOrSubtype: 2,
@@ -1722,6 +1937,7 @@ const normalMonsters = {
       text: "Beast – He's one of the Ojama Trio. It's said that he butts in by any means necessary. It's also said that when the three are together, something happens."
    },
    "One-Eyed Shield Dragon": {
+      id: "33064647",
       cardType: NORMAL_MONSTER,
       attribute: WIND,
       levelOrSubtype: 3,
@@ -1730,6 +1946,7 @@ const normalMonsters = {
       text: "Dragon – This dragon wears a shield not only for its own protection, but also for ramming its enemies."
    },
    "Oni Tank T-34": {
+      id: "66927994",
       cardType: NORMAL_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 4,
@@ -1738,6 +1955,7 @@ const normalMonsters = {
       text: "Machine – An armored tank possessed by a fiend that will pursue enemies until they're crushed."
    },
    "Oppressed People": {
+      id: "58538870",
       cardType: NORMAL_MONSTER,
       attribute: WATER,
       levelOrSubtype: 1,
@@ -1746,6 +1964,7 @@ const normalMonsters = {
       text: "Aqua – They are oppressed, but believe they will have their freedom someday."
    },
    Opticlops: {
+      id: "14531242",
       cardType: NORMAL_MONSTER,
       attribute: DARK,
       levelOrSubtype: 4,
@@ -1754,6 +1973,7 @@ const normalMonsters = {
       text: 'Fiend – A one-eyed giant that serves the "Dark Ruler Ha Des", it skewers its enemies with its sharp horn, shattering them to pieces.'
    },
    "Oscillo Hero": {
+      id: "82065276",
       cardType: NORMAL_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 3,
@@ -1762,6 +1982,7 @@ const normalMonsters = {
       text: "Warrior – A strange warrior from another dimension."
    },
    Overdrive: {
+      id: "02311603",
       cardType: NORMAL_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 4,
@@ -1770,6 +1991,7 @@ const normalMonsters = {
       text: "Machine – An all-terrain armored vehicle armed with a heavy-duty machine gun."
    },
    "Pale Beast": {
+      id: "21263083",
       cardType: NORMAL_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 4,
@@ -1778,6 +2000,7 @@ const normalMonsters = {
       text: "Beast – With skin tinged bluish-white, this strange creature is a fearsome sight to behold."
    },
    "Parrot Dragon": {
+      id: "62762898",
       cardType: NORMAL_MONSTER,
       attribute: WIND,
       levelOrSubtype: 5,
@@ -1786,6 +2009,7 @@ const normalMonsters = {
       text: "Dragon – A dragon from the cartoons that's more dangerous than it appears to be."
    },
    Peacock: {
+      id: "20624263",
       cardType: NORMAL_MONSTER,
       attribute: WIND,
       levelOrSubtype: 5,
@@ -1794,6 +2018,7 @@ const normalMonsters = {
       text: "Winged Beast – A large peacock that launches its feathers in a lethal attack."
    },
    "People Running About": {
+      id: "12143771",
       cardType: NORMAL_MONSTER,
       attribute: FIRE,
       levelOrSubtype: 2,
@@ -1802,6 +2027,7 @@ const normalMonsters = {
       text: "Pyro – Although they always suffer in silence, they swear an oath to inevitably revolt."
    },
    "Petit Angel": {
+      id: "38142739",
       cardType: NORMAL_MONSTER,
       attribute: LIGHT,
       levelOrSubtype: 3,
@@ -1810,6 +2036,7 @@ const normalMonsters = {
       text: "Fairy – A quick-moving and tiny fairy that's very difficult to hit."
    },
    "Petit Dragon": {
+      id: "75356564",
       cardType: NORMAL_MONSTER,
       attribute: WIND,
       levelOrSubtype: 2,
@@ -1818,6 +2045,7 @@ const normalMonsters = {
       text: "Dragon – A very small dragon known for its vicious attacks."
    },
    "Petit Moth": {
+      id: "58192742",
       cardType: NORMAL_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 1,
@@ -1826,6 +2054,7 @@ const normalMonsters = {
       text: "Insect – This small but deadly creature is better off avoided."
    },
    "Pharaoh's Servant": {
+      id: "52550973",
       cardType: NORMAL_MONSTER,
       attribute: DARK,
       levelOrSubtype: 2,
@@ -1834,6 +2063,7 @@ const normalMonsters = {
       text: "Zombie – An apparition of those said to formerly serve the Pharaoh. It has tremendous loyalty that does not waiver."
    },
    "Pharaonic Protector": {
+      id: "89959682",
       cardType: NORMAL_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 2,
@@ -1842,6 +2072,7 @@ const normalMonsters = {
       text: "Zombie – The mummy of a soldier that has been guarding the royal family for thousands of years. Even now, its spirit does not allow anybody to trespass."
    },
    "Prevent Rat": {
+      id: "0549481",
       cardType: NORMAL_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 4,
@@ -1850,6 +2081,7 @@ const normalMonsters = {
       text: "Beast – This creature is shielded with a tough hide of hair and is excellent at defending itself."
    },
    "Protector of the Throne": {
+      id: "10071456",
       cardType: NORMAL_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 4,
@@ -1858,6 +2090,7 @@ const normalMonsters = {
       text: "Warrior – While the king is away, this queen protects his throne with a mighty defense."
    },
    "Psychic Kappa": {
+      id: "07892180",
       cardType: NORMAL_MONSTER,
       attribute: WATER,
       levelOrSubtype: 2,
@@ -1866,6 +2099,7 @@ const normalMonsters = {
       text: "Aqua – An amphibian with a myriad of powers to shield it from enemy attacks."
    },
    "Queen Bird": {
+      id: "73081602",
       cardType: NORMAL_MONSTER,
       attribute: WIND,
       levelOrSubtype: 5,
@@ -1874,6 +2108,7 @@ const normalMonsters = {
       text: "Winged Beast – This monster attacks using its huge beak."
    },
    "Queen of Autumn Leaves": {
+      id: "04179849",
       cardType: NORMAL_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 5,
@@ -1882,6 +2117,7 @@ const normalMonsters = {
       text: "Plant – Queen of the Emerald Forest and wife of the Spirit King, she lives surrounded by vivid red leaves."
    },
    "Ray & Temperature": {
+      id: "85309439",
       cardType: NORMAL_MONSTER,
       attribute: LIGHT,
       levelOrSubtype: 3,
@@ -1890,6 +2126,7 @@ const normalMonsters = {
       text: "Fairy – The Sun and the North Wind join hands to deliver a devastating combination of heat and gale-force winds."
    },
    "Red Archery Girl": {
+      id: "65570596",
       cardType: NORMAL_MONSTER,
       attribute: WATER,
       levelOrSubtype: 4,
@@ -1898,6 +2135,7 @@ const normalMonsters = {
       text: "Aqua – A mermaid archer that hides in a protective shell, waiting for the right moment to strike."
    },
    "Red-Eyes Black Dragon": {
+      id: "74677422",
       cardType: NORMAL_MONSTER,
       attribute: DARK,
       levelOrSubtype: 7,
@@ -1906,6 +2144,7 @@ const normalMonsters = {
       text: "Dragon – A ferocious dragon with a deadly attack."
    },
    "Right Arm of the Forbidden One": {
+      id: "70903634",
       cardType: NORMAL_MONSTER,
       attribute: DARK,
       levelOrSubtype: 1,
@@ -1914,6 +2153,7 @@ const normalMonsters = {
       text: "Spellcaster – A forbidden right arm sealed by magic. Whosoever breaks this seal will know infinite power."
    },
    "Right Leg of the Forbidden One": {
+      id: "08124921",
       cardType: NORMAL_MONSTER,
       attribute: DARK,
       levelOrSubtype: 1,
@@ -1922,6 +2162,7 @@ const normalMonsters = {
       text: "Spellcaster – A forbidden right leg sealed by magic. Whosoever breaks this seal will know infinite power."
    },
    Robolady: {
+      id: "92421852",
       cardType: NORMAL_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 3,
@@ -1930,6 +2171,7 @@ const normalMonsters = {
       text: 'Machine – A warrior fully covered with metal. It upgrades by fusing with "Roboyarou".'
    },
    "Robotic Knight": {
+      id: "44203504",
       cardType: NORMAL_MONSTER,
       attribute: FIRE,
       levelOrSubtype: 4,
@@ -1938,6 +2180,7 @@ const normalMonsters = {
       text: "Machine – The Commander of Machine-Types, he serves the Machine King. He is famous for the way he controls his troops."
    },
    Roboyarou: {
+      id: "38916461",
       cardType: NORMAL_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 3,
@@ -1946,6 +2189,7 @@ const normalMonsters = {
       text: 'Machine – A warrior fully covered with metal. It upgrades by fusing with "Robolady".'
    },
    "Rock Ogre Grotto #1": {
+      id: "68846917",
       cardType: NORMAL_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 3,
@@ -1954,6 +2198,7 @@ const normalMonsters = {
       text: "Rock – Protected by a solid body of rock, this monster throws a bone-shattering punch."
    },
    "Rogue Doll": {
+      id: "91939608",
       cardType: NORMAL_MONSTER,
       attribute: LIGHT,
       levelOrSubtype: 4,
@@ -1962,6 +2207,7 @@ const normalMonsters = {
       text: "Spellcaster – A deadly doll gifted with mystical power, it is particularly powerful when attacking against dark forces."
    },
    "Root Water": {
+      id: "39004808",
       cardType: NORMAL_MONSTER,
       attribute: WATER,
       levelOrSubtype: 3,
@@ -1970,6 +2216,7 @@ const normalMonsters = {
       text: "Fish – An amphibian capable of calling up a massive tidal wave from the dark seas to wipe out enemy monsters."
    },
    "Rude Kaiser": {
+      id: "26378150",
       cardType: NORMAL_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 5,
@@ -1978,6 +2225,7 @@ const normalMonsters = {
       text: "Beast-Warrior – With an axe in each hand, this monster delivers heavy damage."
    },
    "Ryu-Kishin": {
+      id: "15303296",
       cardType: NORMAL_MONSTER,
       attribute: DARK,
       levelOrSubtype: 3,
@@ -1986,6 +2234,7 @@ const normalMonsters = {
       text: "Fiend – A very elusive creature that looks like a harmless statue until it attacks."
    },
    "Ryu-Kishin Powered": {
+      id: "24611934",
       cardType: NORMAL_MONSTER,
       attribute: LIGHT,
       levelOrSubtype: 4,
@@ -1994,6 +2243,7 @@ const normalMonsters = {
       text: "Fiend – A gargoyle enhanced by the powers of darkness. Very sharp talons make it a worthy opponent."
    },
    "Ryu-Ran": {
+      id: "02964201",
       cardType: NORMAL_MONSTER,
       attribute: FIRE,
       levelOrSubtype: 7,
@@ -2002,6 +2252,7 @@ const normalMonsters = {
       text: "Dragon – A vicious little dragon sheltered in an egg that looks deceptively harmless."
    },
    "Saggi the Dark Clown": {
+      id: "66602787",
       cardType: NORMAL_MONSTER,
       attribute: DARK,
       levelOrSubtype: 3,
@@ -2010,6 +2261,7 @@ const normalMonsters = {
       text: "Spellcaster – This clown appears from nowhere and executes very strange moves to avoid enemy attacks."
    },
    "Sand Stone": {
+      id: "73051941",
       cardType: NORMAL_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 5,
@@ -2018,6 +2270,7 @@ const normalMonsters = {
       text: "Rock – Appears from underground and attacks with long, snake-like tentacles."
    },
    "Science Soldier": {
+      id: "67532912",
       cardType: NORMAL_MONSTER,
       attribute: DARK,
       levelOrSubtype: 3,
@@ -2026,6 +2279,7 @@ const normalMonsters = {
       text: "Warrior – Soldiers equipped with state-of-the-art weaponry to face unknown creatures."
    },
    "Sea Serpent Warrior of Darkness": {
+      id: "42071342",
       cardType: NORMAL_MONSTER,
       attribute: WATER,
       levelOrSubtype: 4,
@@ -2034,6 +2288,7 @@ const normalMonsters = {
       text: "Sea Serpent – A warrior who defends the world of the Sea of Darkness. He prides himself on his fighting prowess both on the ground and, of course, in the water."
    },
    "Sealmaster Meisei": {
+      id: "02468169",
       cardType: NORMAL_MONSTER,
       attribute: DARK,
       levelOrSubtype: 3,
@@ -2042,6 +2297,7 @@ const normalMonsters = {
       text: "Spellcaster – One of the few people who has a good command of Talismans. His history is a mystery."
    },
    Seiyaryu: {
+      id: "06740720",
       cardType: NORMAL_MONSTER,
       attribute: LIGHT,
       levelOrSubtype: 7,
@@ -2050,6 +2306,7 @@ const normalMonsters = {
       text: "Dragon – A mystical dragon that burns away the unworthy with its mystic flames."
    },
    "Serpent Night Dragon": {
+      id: "66516792",
       cardType: NORMAL_MONSTER,
       attribute: DARK,
       levelOrSubtype: 7,
@@ -2058,6 +2315,7 @@ const normalMonsters = {
       text: "Dragon – A dragon created from the soul of a wicked knight."
    },
    Shapesnatch: {
+      id: "04035199",
       cardType: NORMAL_MONSTER,
       attribute: DARK,
       levelOrSubtype: 5,
@@ -2066,6 +2324,7 @@ const normalMonsters = {
       text: "Machine – A bow tie with horrible power, it attacks an opponent by controlling others."
    },
    "Shining Abyss": {
+      id: "87303357",
       cardType: NORMAL_MONSTER,
       attribute: LIGHT,
       levelOrSubtype: 4,
@@ -2074,6 +2333,7 @@ const normalMonsters = {
       text: "Fairy – This monster employs the powers of both Light and Darkness."
    },
    "Shining Friendship": {
+      id: "82085619",
       cardType: NORMAL_MONSTER,
       attribute: LIGHT,
       levelOrSubtype: 4,
@@ -2082,6 +2342,7 @@ const normalMonsters = {
       text: "Fairy – The peacemaker among monsters."
    },
    "Silver Fang": {
+      id: "90357090",
       cardType: NORMAL_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 3,
@@ -2090,6 +2351,7 @@ const normalMonsters = {
       text: "Beast – A snow wolf that's beautiful to the eye, but absolutely vicious in battle."
    },
    "Skull Dog Marron": {
+      id: "86652646",
       cardType: NORMAL_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 4,
@@ -2098,6 +2360,7 @@ const normalMonsters = {
       text: "Beast – A lost dog that wandered off 1000 years ago. He's still waiting for his master to come for him."
    },
    "Skull Mariner": {
+      id: "05265750",
       cardType: NORMAL_MONSTER,
       attribute: WATER,
       levelOrSubtype: 4,
@@ -2106,6 +2369,7 @@ const normalMonsters = {
       text: "Warrior – A pirate ship that appears out of the mist and sinks any seagoing vessels."
    },
    "Skull Red Bird": {
+      id: "10202894",
       cardType: NORMAL_MONSTER,
       attribute: WIND,
       levelOrSubtype: 4,
@@ -2114,6 +2378,7 @@ const normalMonsters = {
       text: "Winged Beast – This monster swoops down and attacks with a rain of knives stored in its wings."
    },
    "Skull Servant": {
+      id: "32274490",
       cardType: NORMAL_MONSTER,
       attribute: DARK,
       levelOrSubtype: 1,
@@ -2122,6 +2387,7 @@ const normalMonsters = {
       text: "Zombie – A skeletal ghost that isn't strong, but can mean trouble in large numbers."
    },
    "Sky Dragon": {
+      id: "95288024",
       cardType: NORMAL_MONSTER,
       attribute: WIND,
       levelOrSubtype: 6,
@@ -2130,6 +2396,7 @@ const normalMonsters = {
       text: "Dragon – A flying dragon with four wings housing some very dangerous blades."
    },
    "Sky Scout": {
+      id: "30532390",
       cardType: NORMAL_MONSTER,
       attribute: WIND,
       levelOrSubtype: 4,
@@ -2138,6 +2405,7 @@ const normalMonsters = {
       text: "Winged Beast – With eyes like a hawk and a flying speed exceeding Mach 5, this monster is a master of the sky."
    },
    "Sleeping Lion": {
+      id: "40200834",
       cardType: NORMAL_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 4,
@@ -2146,6 +2414,7 @@ const normalMonsters = {
       text: "Beast – A ferocious animal that sleeps all day. Sometimes it's better to let Sleeping Lions lie."
    },
    "Slime Toad": {
+      id: "68638985",
       cardType: NORMAL_MONSTER,
       attribute: WATER,
       levelOrSubtype: 2,
@@ -2154,6 +2423,7 @@ const normalMonsters = {
       text: "Aqua – A slime with the head of a frog, it attacks by croaking terribly."
    },
    "Slot Machine": {
+      id: "03797883",
       cardType: NORMAL_MONSTER,
       attribute: DARK,
       levelOrSubtype: 7,
@@ -2162,6 +2432,7 @@ const normalMonsters = {
       text: "Machine – The machine's ability is said to vary according to its slot results."
    },
    "Sonic Duck": {
+      id: "84696266",
       cardType: NORMAL_MONSTER,
       attribute: WIND,
       levelOrSubtype: 3,
@@ -2170,6 +2441,7 @@ const normalMonsters = {
       text: "Winged Beast – A duck which can walk at a sonic speed. Sometimes, he cannot deal with his incredible pace and loses control."
    },
    "Sonic Maid": {
+      id: "38942059",
       cardType: NORMAL_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 3,
@@ -2178,6 +2450,7 @@ const normalMonsters = {
       text: "Warrior – A maiden that uses sound to her advantage, she wields a scythe that's shaped like a musical note."
    },
    "Sorcerer of the Doomed": {
+      id: "49218300",
       cardType: NORMAL_MONSTER,
       attribute: DARK,
       levelOrSubtype: 4,
@@ -2186,6 +2459,7 @@ const normalMonsters = {
       text: "Spellcaster – A slave of the dark arts, this sorcerer is a master of death-dealing spells."
    },
    "Soul Tiger": {
+      id: "15734813",
       cardType: NORMAL_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 4,
@@ -2194,6 +2468,7 @@ const normalMonsters = {
       text: "Beast – The soul of a tiger that is said to devour human souls. He is a famous soul that you wouldn't want to run into in a dark alley."
    },
    Souleater: {
+      id: "31242786",
       cardType: NORMAL_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 4,
@@ -2202,6 +2477,7 @@ const normalMonsters = {
       text: "Fish – A living wonder of mystery."
    },
    "Souls of the Forgotten": {
+      id: "04920010",
       cardType: NORMAL_MONSTER,
       attribute: DARK,
       levelOrSubtype: 2,
@@ -2210,6 +2486,7 @@ const normalMonsters = {
       text: "Fiend – A wicked spirit created by the hateful souls of those who fell in battle. It grows by assimilating the souls of its enemies."
    },
    "Space Mambo": {
+      id: "36119641",
       cardType: NORMAL_MONSTER,
       attribute: WATER,
       levelOrSubtype: 4,
@@ -2218,6 +2495,7 @@ const normalMonsters = {
       text: "Fish – A Space Mambo floating in the vast universe. This living relic was found in the ruins of a super civilization on Alphard 4."
    },
    "Spherous Lady": {
+      id: "52121290",
       cardType: NORMAL_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 3,
@@ -2226,6 +2504,7 @@ const normalMonsters = {
       text: "Rock – Many have been deceived by the beauty of this vampire."
    },
    "Spike Seadra": {
+      id: "85326399",
       cardType: NORMAL_MONSTER,
       attribute: WATER,
       levelOrSubtype: 5,
@@ -2234,6 +2513,7 @@ const normalMonsters = {
       text: "Sea Serpent – Using the spikes sprouting from its body, this creature stabs its opponents and floods them with electricity."
    },
    Spikebot: {
+      id: "87511987",
       cardType: NORMAL_MONSTER,
       attribute: DARK,
       levelOrSubtype: 5,
@@ -2242,6 +2522,7 @@ const normalMonsters = {
       text: "Machine – A mechanical soldier created by a wicked sorcerer, it attacks with the two steel balls attached to its arms."
    },
    "Spirit of the Books": {
+      id: "14037717",
       cardType: NORMAL_MONSTER,
       attribute: WIND,
       levelOrSubtype: 4,
@@ -2250,6 +2531,7 @@ const normalMonsters = {
       text: "Winged Beast – This wise spirit dwells in books, using its accumulated knowledge to defeat enemies."
    },
    "Spirit of the Harp": {
+      id: "80770678",
       cardType: NORMAL_MONSTER,
       attribute: LIGHT,
       levelOrSubtype: 4,
@@ -2258,6 +2540,7 @@ const normalMonsters = {
       text: "Fairy – A spirit that soothes the soul with the music of its heavenly harp."
    },
    "Steel Ogre Grotto #1": {
+      id: "29172562",
       cardType: NORMAL_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 5,
@@ -2266,6 +2549,7 @@ const normalMonsters = {
       text: "Machine – A steel idol worshiped in the Land of Machines."
    },
    "Steel Ogre Grotto #2": {
+      id: "90908427",
       cardType: NORMAL_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 6,
@@ -2274,6 +2558,7 @@ const normalMonsters = {
       text: "Machine – A mechanized iron doll with tremedous strength."
    },
    "Stone Ogre Grotto": {
+      id: "15023985",
       cardType: NORMAL_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 5,
@@ -2282,6 +2567,7 @@ const normalMonsters = {
       text: "Rock – A behemoth shaped by giant boulders."
    },
    "Stuffed Animal": {
+      id: "71068263",
       cardType: NORMAL_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 3,
@@ -2290,6 +2576,7 @@ const normalMonsters = {
       text: "Warrior – It may look like a harmless stuffed animal, but its zipper mouth deals a deadly bite."
    },
    "Succubus Knight": {
+      id: "55291359",
       cardType: NORMAL_MONSTER,
       attribute: DARK,
       levelOrSubtype: 5,
@@ -2298,6 +2585,7 @@ const normalMonsters = {
       text: "Warrior – A warrior wizard adept in casting bone-chilling spells."
    },
    "Summoned Skull": {
+      id: "70781052",
       cardType: NORMAL_MONSTER,
       attribute: DARK,
       levelOrSubtype: 6,
@@ -2306,6 +2594,7 @@ const normalMonsters = {
       text: "Fiend – A fiend with dark powers for confusing the enemy. Among the Fiend-Type monsters, this monster boasts considerable force."
    },
    "Swordsman of Landstar": {
+      id: "03573512",
       cardType: NORMAL_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 3,
@@ -2314,6 +2603,7 @@ const normalMonsters = {
       text: "Warrior – An amateur with a sword, this fairy warrior relies on its mysterious powers."
    },
    Swordstalker: {
+      id: "50005633",
       cardType: NORMAL_MONSTER,
       attribute: DARK,
       levelOrSubtype: 6,
@@ -2322,6 +2612,7 @@ const normalMonsters = {
       text: "Warrior – A monster formed by the vengeful souls of those who passed away in battle."
    },
    Takriminos: {
+      id: "44073668",
       cardType: NORMAL_MONSTER,
       attribute: WATER,
       levelOrSubtype: 4,
@@ -2330,6 +2621,7 @@ const normalMonsters = {
       text: "Sea Serpent – A member of a race of sea serpents that freely travels through the sea."
    },
    Takuhee: {
+      id: "03170832",
       cardType: NORMAL_MONSTER,
       attribute: WIND,
       levelOrSubtype: 4,
@@ -2338,6 +2630,7 @@ const normalMonsters = {
       text: "Winged Beast – This bird is known far and wide as a harbinger of doom."
    },
    "Terra the Terrible": {
+      id: "63308047",
       cardType: NORMAL_MONSTER,
       attribute: DARK,
       levelOrSubtype: 4,
@@ -2346,6 +2639,7 @@ const normalMonsters = {
       text: "Fiend – Known as a swamp dweller, this creature is a minion of the dark forces."
    },
    "Terrorking Salmon": {
+      id: "78060096",
       cardType: NORMAL_MONSTER,
       attribute: WATER,
       levelOrSubtype: 5,
@@ -2354,6 +2648,7 @@ const normalMonsters = {
       text: "Fish – A feared salmon, master of the Sea of Darkness. Its roe is the best delicacy in the World of Darkness."
    },
    "The 13th Grave": {
+      id: "0032864",
       cardType: NORMAL_MONSTER,
       attribute: DARK,
       levelOrSubtype: 3,
@@ -2362,6 +2657,7 @@ const normalMonsters = {
       text: "Zombie – A zombie that suddenly appeared from plot #13 – an empty grave."
    },
    "The All-Seeing White Tiger": {
+      id: "32269855",
       cardType: NORMAL_MONSTER,
       attribute: WIND,
       levelOrSubtype: 3,
@@ -2370,6 +2666,7 @@ const normalMonsters = {
       text: "Beast – A proud ruler of the jungle that some fear and others respect."
    },
    "The Dragon Dwelling in the Cave": {
+      id: "93346024",
       cardType: NORMAL_MONSTER,
       attribute: WIND,
       levelOrSubtype: 4,
@@ -2378,6 +2675,7 @@ const normalMonsters = {
       text: "Dragon – A huge dragon dwelling in a cave. It is horrible when it gets angry, although it is usually quiet. It is said to preserve certain treasures."
    },
    "The Earl of Demise": {
+      id: "66989694",
       cardType: NORMAL_MONSTER,
       attribute: DARK,
       levelOrSubtype: 5,
@@ -2386,6 +2684,7 @@ const normalMonsters = {
       text: "Fiend – This gentlemanly creature is extremely wicked, feared by man and fiend alike."
    },
    "The Furious Sea King": {
+      id: "18710707",
       cardType: NORMAL_MONSTER,
       attribute: WATER,
       levelOrSubtype: 3,
@@ -2394,6 +2693,7 @@ const normalMonsters = {
       text: "Aqua – Grand King of the Seven Seas, he's able to summon massive tidal waves to drown the enemy."
    },
    "The Gross Ghost of Fled Dreams": {
+      id: "68049471",
       cardType: NORMAL_MONSTER,
       attribute: DARK,
       levelOrSubtype: 4,
@@ -2402,6 +2702,7 @@ const normalMonsters = {
       text: "Fiend – This monster feeds on the dreams of an unwary sleeper, dragging the victim into eternal slumber."
    },
    "The Illusory Gentleman": {
+      id: "83764996",
       cardType: NORMAL_MONSTER,
       attribute: DARK,
       levelOrSubtype: 4,
@@ -2410,6 +2711,7 @@ const normalMonsters = {
       text: "Spellcaster – Wearing odd fashions, this gentleman is very fickle. He sometimes saves people and at other times commits crimes."
    },
    "The Judgement Hand": {
+      id: "28003512",
       cardType: NORMAL_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 3,
@@ -2418,6 +2720,7 @@ const normalMonsters = {
       text: "Warrior – An all-powerful hand that delivers ruthless attacks."
    },
    "The Portrait's Secret": {
+      id: "32541773",
       cardType: NORMAL_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 4,
@@ -2426,6 +2729,7 @@ const normalMonsters = {
       text: "Fiend – A portrait cursed by the artist, it is said to bring ill fortune to anyone who owns it."
    },
    "The Statue of Easter Island": {
+      id: "10262698",
       cardType: NORMAL_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 4,
@@ -2434,6 +2738,7 @@ const normalMonsters = {
       text: "Rock – A stone monument from Easter Island that launches laser blasts from its rock-hewn lips."
    },
    "Thousand-Eyes Idol": {
+      id: "27125110",
       cardType: NORMAL_MONSTER,
       attribute: DARK,
       levelOrSubtype: 1,
@@ -2442,6 +2747,7 @@ const normalMonsters = {
       text: "Spellcaster – A wicked entity that controls the hearts of men, its thousand eyes are able to see and expand the negative influences in an individual's soul."
    },
    "Three-Headed Geedo": {
+      id: "78423643",
       cardType: NORMAL_MONSTER,
       attribute: DARK,
       levelOrSubtype: 4,
@@ -2450,6 +2756,7 @@ const normalMonsters = {
       text: "Fiend – A three-headed nocturnal monster that is absolutely ruthless when fighting."
    },
    "Three-Legged Zombies": {
+      id: "33734439",
       cardType: NORMAL_MONSTER,
       attribute: DARK,
       levelOrSubtype: 3,
@@ -2458,6 +2765,7 @@ const normalMonsters = {
       text: "Zombie – A pair of friendly skeletons, lean and fat, that travel with extreme difficulty."
    },
    "Tiger Axe": {
+      id: "49791927",
       cardType: NORMAL_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 4,
@@ -2466,6 +2774,7 @@ const normalMonsters = {
       text: "Beast-Warrior – A fast and powerful axe-wielding beast-warrior."
    },
    Tongyo: {
+      id: "69572024",
       cardType: NORMAL_MONSTER,
       attribute: WATER,
       levelOrSubtype: 4,
@@ -2474,6 +2783,7 @@ const normalMonsters = {
       text: "Fish – This monster captures other fish with its long tongue and sucks the energy out of them."
    },
    "Toon Alligator": {
+      id: "59383041",
       cardType: NORMAL_MONSTER,
       attribute: WATER,
       levelOrSubtype: 4,
@@ -2482,6 +2792,7 @@ const normalMonsters = {
       text: "Reptile – An alligator monster straight from the cartoons."
    },
    Trent: {
+      id: "78780140",
       cardType: NORMAL_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 5,
@@ -2490,6 +2801,7 @@ const normalMonsters = {
       text: "Plant – A guardian of the woods, this massive tree is believed to be immortal."
    },
    "Tri-Horned Dragon": {
+      id: "39111158",
       cardType: NORMAL_MONSTER,
       attribute: DARK,
       levelOrSubtype: 8,
@@ -2498,6 +2810,7 @@ const normalMonsters = {
       text: "Dragon – An unworthy dragon with three sharp horns sprouting from its head."
    },
    "Trial of Nightmare": {
+      id: "77827521",
       cardType: NORMAL_MONSTER,
       attribute: DARK,
       levelOrSubtype: 4,
@@ -2506,6 +2819,7 @@ const normalMonsters = {
       text: "Fiend – This fiend passes judgment on enemies that are locked in coffins."
    },
    "Tripwire Beast": {
+      id: "45042329",
       cardType: NORMAL_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 4,
@@ -2514,6 +2828,7 @@ const normalMonsters = {
       text: "Thunder – This creature attacks with electromagnetic waves."
    },
    "Turtle Bird": {
+      id: "72929454",
       cardType: NORMAL_MONSTER,
       attribute: WATER,
       levelOrSubtype: 6,
@@ -2522,6 +2837,7 @@ const normalMonsters = {
       text: "Aqua – An unusual turtle that not only swims at tremendous speeds, but can also sail across the skies."
    },
    "Turtle Tiger": {
+      id: "37313348",
       cardType: NORMAL_MONSTER,
       attribute: WATER,
       levelOrSubtype: 4,
@@ -2530,6 +2846,7 @@ const normalMonsters = {
       text: "Aqua – A tiger encased in a protective shell that attacks with razor-sharp fangs."
    },
    "Turu-Purun": {
+      id: "59053232",
       cardType: NORMAL_MONSTER,
       attribute: WATER,
       levelOrSubtype: 2,
@@ -2538,6 +2855,7 @@ const normalMonsters = {
       text: "Aqua – A strange, one-eyed monster that can fell an enemy with a single stab of its spear."
    },
    "Twin Long Rods #2": {
+      id: "29692206",
       cardType: NORMAL_MONSTER,
       attribute: WATER,
       levelOrSubtype: 3,
@@ -2546,6 +2864,7 @@ const normalMonsters = {
       text: "Aqua – An amphibious creature with two whip-like tails."
    },
    "Twin-Headed Fire Dragon": {
+      id: "78984772",
       cardType: NORMAL_MONSTER,
       attribute: FIRE,
       levelOrSubtype: 6,
@@ -2554,6 +2873,7 @@ const normalMonsters = {
       text: "Pyro – Two dragons fused as one from the effects of the Big Bang."
    },
    "Two-Headed King Rex": {
+      id: "94119974",
       cardType: NORMAL_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 4,
@@ -2562,6 +2882,7 @@ const normalMonsters = {
       text: "Dinosaur – A powerful monster whose two heads attack as one."
    },
    "Two-Mouth Darkruler": {
+      id: "57305373",
       cardType: NORMAL_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 3,
@@ -2570,6 +2891,7 @@ const normalMonsters = {
       text: "Dragon – A dinosaur with two deadly jaws, it stores electricity in its horn and releases high voltage bolts from the mouth on its back."
    },
    Tyhone: {
+      id: "72842870",
       cardType: NORMAL_MONSTER,
       attribute: WIND,
       levelOrSubtype: 4,
@@ -2578,6 +2900,7 @@ const normalMonsters = {
       text: "Winged Beast – Capable of firing cannonballs from its mouth for long-range attacks, this creature is particularly effective in mountain battles."
    },
    "Tyhone #2": {
+      id: "56789759",
       cardType: NORMAL_MONSTER,
       attribute: FIRE,
       levelOrSubtype: 6,
@@ -2586,6 +2909,7 @@ const normalMonsters = {
       text: "Dragon – A crimson dragon that spits fireballs to create a blazing sea of fire."
    },
    "United Resistance": {
+      id: "85936485",
       cardType: NORMAL_MONSTER,
       attribute: WIND,
       levelOrSubtype: 3,
@@ -2594,6 +2918,7 @@ const normalMonsters = {
       text: "Thunder – The people that gather to swear to fight their oppressors. A revolution is coming."
    },
    "Unknown Warrior of Fiend": {
+      id: "97360116",
       cardType: NORMAL_MONSTER,
       attribute: DARK,
       levelOrSubtype: 3,
@@ -2602,6 +2927,7 @@ const normalMonsters = {
       text: "Warrior – A deadly duo consisting of a beast master and its loyal servant."
    },
    Uraby: {
+      id: "01784619",
       cardType: NORMAL_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 4,
@@ -2610,6 +2936,7 @@ const normalMonsters = {
       text: "Dinosaur – Fast on its feet, this dinosaur rips enemies to shreds with its sharp claws."
    },
    "Ushi Oni": {
+      id: "48649353",
       cardType: NORMAL_MONSTER,
       attribute: DARK,
       levelOrSubtype: 6,
@@ -2618,6 +2945,7 @@ const normalMonsters = {
       text: "Fiend – A bull fiend restored by the dark arts, this monster appears out of a jar."
    },
    "Warrior Dai Grepher": {
+      id: "75953262",
       cardType: NORMAL_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 4,
@@ -2626,6 +2954,7 @@ const normalMonsters = {
       text: "Warrior – The warrior who can manipulate dragons. Nobody knows his mysterious past."
    },
    "Warrior of Zera": {
+      id: "66073051",
       cardType: NORMAL_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 4,
@@ -2634,6 +2963,7 @@ const normalMonsters = {
       text: "Warrior – A wandering warrior who seeks the sanctuary where he can gain the power of the Archlords. To escape the temptation of evil fiends, he fights solo day by day."
    },
    "Water Magician": {
+      id: "93343894",
       cardType: NORMAL_MONSTER,
       attribute: WATER,
       levelOrSubtype: 4,
@@ -2642,6 +2972,7 @@ const normalMonsters = {
       text: "Aqua – This monster swamps an opponent with an almost endless supply of water."
    },
    "Water Omotics": {
+      id: "02483611",
       cardType: NORMAL_MONSTER,
       attribute: WATER,
       levelOrSubtype: 4,
@@ -2650,6 +2981,7 @@ const normalMonsters = {
       text: "Aqua – Transforms the water overflowing from a jar into attacking dragons."
    },
    Wattkid: {
+      id: "27324313",
       cardType: NORMAL_MONSTER,
       attribute: LIGHT,
       levelOrSubtype: 3,
@@ -2658,6 +2990,7 @@ const normalMonsters = {
       text: "Thunder – A creature that electrocutes opponents with bolts of lightning."
    },
    "Whiptail Crow": {
+      id: "91996584",
       cardType: NORMAL_MONSTER,
       attribute: DARK,
       levelOrSubtype: 4,
@@ -2666,6 +2999,7 @@ const normalMonsters = {
       text: "Fiend – Attacks from the sky with a whip-like tail."
    },
    "Winged Dragon, Guardian of the Fortress #1": {
+      id: "87796900",
       cardType: NORMAL_MONSTER,
       attribute: WIND,
       levelOrSubtype: 4,
@@ -2674,6 +3008,7 @@ const normalMonsters = {
       text: "Dragon – A dragon commonly found guarding mountain fortresses. Its signature attack is a sweeping dive from out of the blue."
    },
    "Winged Dragon, Guardian of the Fortress #2": {
+      id: "57405307",
       cardType: NORMAL_MONSTER,
       attribute: WIND,
       levelOrSubtype: 4,
@@ -2682,6 +3017,7 @@ const normalMonsters = {
       text: "Winged Beast – This creature's wings are capable of generating tornadoes."
    },
    Wingweaver: {
+      id: "31447217",
       cardType: NORMAL_MONSTER,
       attribute: LIGHT,
       levelOrSubtype: 7,
@@ -2690,6 +3026,7 @@ const normalMonsters = {
       text: "Fairy – A six-winged fairy who prays for peace and hope."
    },
    "Witty Phantom": {
+      id: "36304921",
       cardType: NORMAL_MONSTER,
       attribute: DARK,
       levelOrSubtype: 4,
@@ -2698,6 +3035,7 @@ const normalMonsters = {
       text: "Fiend – Dressed in a night-black tuxedo, this creature presides over death."
    },
    "Wolf Axwielder": {
+      id: "56369281",
       cardType: NORMAL_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 4,
@@ -2706,6 +3044,7 @@ const normalMonsters = {
       text: "Beast-Warrior – Once it has started battle, this monster attacks fiercely and cannot stop."
    },
    "Woodborg Inpachi": {
+      id: "35322812",
       cardType: NORMAL_MONSTER,
       attribute: FIRE,
       levelOrSubtype: 5,
@@ -2714,6 +3053,7 @@ const normalMonsters = {
       text: "Machine – The new form of the enigmatic Inpachi, remodeled by cutting-edge Dark World technology. Maneuverability has been sacrificed for strong armor, which was considered more important."
    },
    "Worm Drake": {
+      id: "73216412",
       cardType: NORMAL_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 4,
@@ -2722,6 +3062,7 @@ const normalMonsters = {
       text: "Reptile – Once this monster wraps itself around a victim, there is no escape."
    },
    "Wow Warrior": {
+      id: "69750536",
       cardType: NORMAL_MONSTER,
       attribute: WATER,
       levelOrSubtype: 4,
@@ -2730,6 +3071,7 @@ const normalMonsters = {
       text: "Fish – A fish with arms?"
    },
    "X-Head Cannon": {
+      id: "62651957",
       cardType: NORMAL_MONSTER,
       attribute: LIGHT,
       levelOrSubtype: 4,
@@ -2738,6 +3080,7 @@ const normalMonsters = {
       text: "Machine – A monster with a mighty cannon barrel, it is able to integrate its attacks. It attacks in many ways by combining and separating with other monsters."
    },
    Yamadron: {
+      id: "70345785",
       cardType: NORMAL_MONSTER,
       attribute: FIRE,
       levelOrSubtype: 5,
@@ -2746,6 +3089,7 @@ const normalMonsters = {
       text: "Dragon – This monster has three fire-breathing heads and can form a sea of blazing flames."
    },
    Yaranzo: {
+      id: "71280811",
       cardType: NORMAL_MONSTER,
       attribute: DARK,
       levelOrSubtype: 4,
@@ -2754,6 +3098,7 @@ const normalMonsters = {
       text: "Zombie – A treasure box containing a monster that attacks any unwary bandit."
    },
    Zoa: {
+      id: "24311372",
       cardType: NORMAL_MONSTER,
       attribute: DARK,
       levelOrSubtype: 7,

--- a/web-app/src/databases/cardDB/monsters/ritualMonsters.js
+++ b/web-app/src/databases/cardDB/monsters/ritualMonsters.js
@@ -2,6 +2,7 @@ import { HERO, RITUAL_MONSTER, SEARCH_DECK, GRAVEYARD, MONSTER, ROLL_DICE, DARK,
 
 const ritualMonsters = {
    "Black Luster Soldier": {
+      id: "05405694",
       cardType: RITUAL_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 8,
@@ -10,6 +11,7 @@ const ritualMonsters = {
       text: 'Warrior/Ritual - You can Ritual Summon this card with "Black Luster Ritual".'
    },
    "Crab Turtle": {
+      id: "91782219",
       cardType: RITUAL_MONSTER,
       attribute: WATER,
       levelOrSubtype: 8,
@@ -18,6 +20,7 @@ const ritualMonsters = {
       text: 'Aqua/Ritual - You can Ritual Summon this card with "Turtle Oath".'
    },
    "Dark Master - Zorc": {
+      id: "97642679",
       cardType: RITUAL_MONSTER,
       attribute: DARK,
       levelOrSubtype: 8,
@@ -34,6 +37,7 @@ const ritualMonsters = {
       }
    },
    Dokurorider: {
+      id: "99721536",
       cardType: RITUAL_MONSTER,
       attribute: DARK,
       levelOrSubtype: 6,
@@ -42,6 +46,7 @@ const ritualMonsters = {
       text: 'Zombie/Ritual - You can Ritual Summon this card with "Revival of Dokurorider".'
    },
    "Elemental Mistress Doriado": {
+      id: "99414168",
       cardType: RITUAL_MONSTER,
       attribute: LIGHT,
       levelOrSubtype: 3,
@@ -50,6 +55,7 @@ const ritualMonsters = {
       text: 'Spellcaster/Effect/Ritual - <effect=Summon>Must be Ritual Summoned with "Doriado\'s Blessing" and cannot be Ritual Summoned by other ways.</effect> <effect=Continuous>The Attribute of this card is also treated as WIND, WATER, FIRE, and EARTH while it is face-up on the field</effect>'
    },
    "Hungry Burger": {
+      id: "30243636",
       cardType: RITUAL_MONSTER,
       attribute: DARK,
       levelOrSubtype: 6,
@@ -58,6 +64,7 @@ const ritualMonsters = {
       text: 'Warrior/Ritual - You can Ritual Summon this card with "Hamburger Recipe".'
    },
    "Legendary Flame Lord": {
+      id: "60258960",
       cardType: RITUAL_MONSTER,
       attribute: FIRE,
       levelOrSubtype: 7,
@@ -66,6 +73,7 @@ const ritualMonsters = {
       text: 'Spellcaster/Effect/Ritual - <effect=Summon>You can Ritual Summon this card with "Incandescent Ordeal".</effect> <effect=Continuous>Each time a Spell is activated, place 1 Spell Counter on this card immediately after it resolves.</effect> <effect=Ignition>You can remove 3 Spell Counters from this card; destroy all monsters on the field, except this card.</effect>'
    },
    "Paladin of White Dragon": {
+      id: "73398797",
       cardType: RITUAL_MONSTER,
       attribute: LIGHT,
       levelOrSubtype: 4,
@@ -87,6 +95,7 @@ const ritualMonsters = {
       }
    },
    "Performance of Sword": {
+      id: "04849037",
       cardType: RITUAL_MONSTER,
       attribute: EARTH,
       levelOrSubtype: 6,
@@ -95,6 +104,7 @@ const ritualMonsters = {
       text: 'Warrior/Ritual - You can Ritual Summon this card with "Commencement Dance".'
    },
    Relinquished: {
+      id: "64631466",
       cardType: RITUAL_MONSTER,
       attribute: DARK,
       levelOrSubtype: 1,
@@ -103,6 +113,7 @@ const ritualMonsters = {
       text: "Spellcaster/Effect/Ritual - <effect=Summon>You can Ritual Summon this card with \"Black Illusion Ritual\".</effect> <effect=Ignition>Once per turn: You can target 1 monster your opponent controls; equip that target to this card (max 1). This card must be face-up on the field to activate and to resolve this effect.</effect> <effect=Continuous>This card's ATK/DEF become equal to that equipped monster's.</effect> <effect=Continuous>If this card would be destroyed by battle, destroy that equipped monster instead.</effect> <effect=Trigger>When an equipped monster is destroyed by this effect: Inflict damage to your opponent equal to the battle damage that you took.</effect>"
    },
    "Reshef the Dark Being": {
+      id: "62420419",
       cardType: RITUAL_MONSTER,
       attribute: LIGHT,
       levelOrSubtype: 8,
@@ -111,6 +122,7 @@ const ritualMonsters = {
       text: 'Fiend/Effect/Ritual - <effect=Summon>Must be Ritual Summoned with "Final Ritual of the Ancients" and cannot be Ritual Summoned by other ways.</effect> <effect=Ignition>Once per turn: You can discard 1 Spell from your hand, then target 1 monster your opponent controls; take control of that target until the end of this turn.</effect>'
    },
    "Shinato, King of a Higher Plane": {
+      id: "86327225",
       cardType: RITUAL_MONSTER,
       attribute: LIGHT,
       levelOrSubtype: 8,
@@ -119,6 +131,7 @@ const ritualMonsters = {
       text: 'Fairy/Effect/Ritual - <effect=Summon>Must be Ritual Summoned with "Shinato\'s Ark" and cannot be Ritual Summoned by other ways.</effect> <effect=Trigger>When this card destroys a Defense Position monster by battle and sends it to the Graveyard: Inflict damage to your opponent equal to its original ATK.</effect>'
    },
    "Skull Guardian": {
+      id: "03627449",
       cardType: RITUAL_MONSTER,
       attribute: LIGHT,
       levelOrSubtype: 7,
@@ -127,6 +140,7 @@ const ritualMonsters = {
       text: 'Warrior/Ritual - You can Ritual Summon this card with "Novox\'s Prayer".'
    },
    "The Masked Beast": {
+      id: "49064413",
       cardType: RITUAL_MONSTER,
       attribute: DARK,
       levelOrSubtype: 8,

--- a/web-app/src/databases/cardDB/spells/continuousSpells.js
+++ b/web-app/src/databases/cardDB/spells/continuousSpells.js
@@ -2,65 +2,77 @@ import { SPELL } from "utils/constants.js";
 
 const continuousSpells = {
    "Kishido Spirit": {
+      id: "60519422",
       cardType: SPELL,
       levelOrSubtype: "Continuous",
       text: "<effect=Continuous-like>Monsters you control are not destroyed by battle if they battle a monster with the same ATK.</effect>"
    },
    "Spring of Rebirth": {
+      id: "94425169",
       cardType: SPELL,
       levelOrSubtype: "Continuous",
       text: "<effect=Trigger-like>When a monster(s) return from the field to the hand: Gain 500 Life Points.</effect>",
       prepopLP: { hero: 500 }
    },
    Stumbling: {
+      id: "34646691",
       cardType: SPELL,
       levelOrSubtype: "Continuous",
       text: "<effect=Trigger-like>If a monster is Summoned: Change it to Defense Position.</effect>"
    },
    "Blessings of the Nile": {
+      id: "30653113",
       cardType: SPELL,
       levelOrSubtype: "Continuous",
       text: "<effect=Trigger-like>Each time a card(s) is discarded from your hand to the Graveyard by an opponent's card effect: Gain 1000 Life Points.</effect>"
    },
    "Chain Energy": {
+      id: "79323590",
       cardType: SPELL,
       levelOrSubtype: "Continuous",
       text: "<effect=Continuous-like>Each player must pay 500 Life Points per card to Normal Summon, Special Summon, Set or activate cards from his/her respective hand.</effect>",
       prepopLP: { hero: -500, villain: -500 }
    },
    "Mass Driver": {
+      id: "34906152",
       cardType: SPELL,
       levelOrSubtype: "Continuous",
       text: "<effect=Ignition-like>You can Tribute 1 monster; inflict 400 damage to your opponent.</effect>"
    },
    "Morale Boost": {
+      id: "93671934",
       cardType: SPELL,
       levelOrSubtype: "Continuous",
       text: "<effect=Continuous-like>Each time an Equip Spell is equipped, its controller gains 1000 Life Points.</effect> <effect=Continuous-like>Each time an Equip Spell leaves the field, its controller takes 1000 damage.</effect>"
    },
    "The Dark Door": {
+      id: "30606547",
       cardType: SPELL,
       levelOrSubtype: "Continuous",
       text: "<effect=Continuous-like>Only 1 monster can attack during each Battle Phase.</effect>"
    },
    Toll: {
+      id: "82003859",
       cardType: SPELL,
       levelOrSubtype: "Continuous",
       text: "<effect=Continuous-like>Players must pay 500 Life Points to declare an attack.</effect>",
       prepopLP: { hero: -500, villain: -500 }
    },
    "Toon World": {
+      id: "15259703",
       cardType: SPELL,
       levelOrSubtype: "Continuous",
       text: "Activate this card by paying 1000 Life Points.",
       prepopLP: { hero: -1000 }
    },
    "Vengeful Bog Spirit": {
+      id: "95220856",
       cardType: SPELL,
       levelOrSubtype: "Continuous",
       text: "<effect=Continuous-like>Monsters cannot attack the turn they are Summoned.</effect>"
    },
    "Yellow Luster Shield": {
+      id: "04542651",
       cardType: SPELL,
       levelOrSubtype: "Continuous",
       text: "<effect=Continuous-like>All monsters you control gain 300 DEF.</effect>"

--- a/web-app/src/databases/cardDB/spells/equipSpells.js
+++ b/web-app/src/databases/cardDB/spells/equipSpells.js
@@ -2,92 +2,110 @@ import { SPELL } from "utils/constants.js";
 
 const equipSpells = {
    Demotion: {
+      id: "72575145",
       cardType: SPELL,
       levelOrSubtype: "Equip",
       text: "<effect=Continuous-like>The equipped monster has its Level reduced by 2.</effect>"
    },
    "Dragon Treasure": {
+      id: "01435851",
       cardType: SPELL,
       levelOrSubtype: "Equip",
       text: "<effect=Continuous-like>Equip only to a Dragon monster. It gains 300 ATK/DEF.</effect>"
    },
    "Follow Wind": {
+      id: "98252586",
       cardType: SPELL,
       levelOrSubtype: "Equip",
       text: "<effect=Continuous-like>Equip only to a Winged-Beast monster. It gains 300 ATK/DEF.</effect>"
    },
    "Germ Infection": {
+      id: "24668830",
       cardType: SPELL,
       levelOrSubtype: "Equip",
       text: "<effect=Continuous-like>Equip only to a non-Machine monster. During its controller's Standby Phase, it loses 300 ATK.</effect>"
    },
    "Laser Cannon Armor": {
+      id: "77007920",
       cardType: SPELL,
       levelOrSubtype: "Equip",
       text: "<effect=Continuous-like>Equip only to an Insect monster. It gains 300 ATK/DEF.</effect>"
    },
    "Machine Conversion Factory": {
+      id: "25769732",
       cardType: SPELL,
       levelOrSubtype: "Equip",
       text: "<effect=Continuous-like>Equip only to a Machine monster. It gains 300 ATK/DEF.</effect>"
    },
    "Silver Bow and Arrow": {
+      id: "01557499",
       cardType: SPELL,
       levelOrSubtype: "Equip",
       text: "<effect=Continuous-like>Equip only to a Fairy monster. It gains 300 ATK/DEF.</effect>"
    },
    "Ballista of Rampart Smashing": {
+      id: "0242146",
       cardType: SPELL,
       levelOrSubtype: "Equip",
       text: "<effect=Continuous-like>If the equipped monster attacks a face-down Defense Position monster, it gains 1500 ATK during damage calculation only.</effect>"
    },
    "Beast Fangs": {
+      id: "46009906",
       cardType: SPELL,
       levelOrSubtype: "Equip",
       text: "<effect=Continuous-like>Equip only to a Beast monster. It gains 300 ATK/DEF.</effect>"
    },
    "Book of Secret Arts": {
+      id: "91595718",
       cardType: SPELL,
       levelOrSubtype: "Equip",
       text: "<effect=Continuous-like>Equip only to a Spellcaster monster. It gains 300 ATK/DEF.</effect>"
    },
    "Metalsilver Armor": {
+      id: "33114323",
       cardType: SPELL,
       levelOrSubtype: "Equip",
       text: "<effect=Continuous-like>If you control the equipped monster, your opponent cannot activate cards or effects that target exactly 1 monster, except the equipped monster.</effect>"
    },
    "Paralyzing Potion": {
+      id: "50152549",
       cardType: SPELL,
       levelOrSubtype: "Equip",
       text: "<effect=Continuous-like>Equip only to a non-Machine monster. It cannot attack.</effect>"
    },
    "Raise Body Heat": {
+      id: "51267887",
       cardType: SPELL,
       levelOrSubtype: "Equip",
       text: "<effect=Continuous-like>Equip only to a Dinosaur monster. It gains 300 ATK/DEF.</effect>"
    },
    "Raregold Armor": {
+      id: "07625614",
       cardType: SPELL,
       levelOrSubtype: "Equip",
       text: "<effect=Continuous-like>Your opponent cannot attack monsters except the equipped monster.</effect>"
    },
    "Horn of Light": {
+      id: "38552107",
       cardType: SPELL,
       levelOrSubtype: "Equip",
       text: "<effect=Continuous-like>The equipped monster gains 800 DEF.</effect> <effect=Trigger-like>When this card is sent from the field to the Graveyard: You can pay 500 Life Points; return it to the top of the Deck.</effect>",
       prepopLP: { hero: -500 }
    },
    "Horn of the Unicorn": {
+      id: "64047146",
       cardType: SPELL,
       levelOrSubtype: "Equip",
       text: "<effect=Continuous-like>The equipped monster gains 700 ATK/DEF.</effect> <effect=Trigger-like>When this card is sent from the field to the Graveyard: Return it to the top of the Deck.</effect>"
    },
    "Vile Germs": {
+      id: "39774685",
       cardType: SPELL,
       levelOrSubtype: "Equip",
       text: "<effect=Continuous-like>Equip only to a Plant monster. It gains 300 ATK/DEF.</effect>"
    },
    "Premature Burial": {
+      id: "70828912",
       cardType: SPELL,
       levelOrSubtype: "Equip",
       text: "Activate this card by paying 800 Life Points, then target 1 monster in your Graveyard; Special Summon that target in Attack Position and equip it with this card. <effect=Continuous-like>When this card is destroyed, destroy the equipped monster.</effect>",
@@ -95,6 +113,7 @@ const equipSpells = {
       limit: 1
    },
    "Snatch Steal": {
+      id: "45986603",
       cardType: SPELL,
       levelOrSubtype: "Equip",
       text: "Equip only to a monster your opponent controls. <effect=Continuous-like>Take control of the equipped monster.</effect> <effect=Trigger-like>During each of your opponent's Standby Phases: They gain 1000 Life Points.</effect>",

--- a/web-app/src/databases/cardDB/spells/fieldSpells.js
+++ b/web-app/src/databases/cardDB/spells/fieldSpells.js
@@ -2,16 +2,19 @@ import { SPELL } from "utils/constants.js";
 
 const fieldSpells = {
    "Chorus of Sanctuary": {
+      id: "81380218",
       cardType: SPELL,
       levelOrSubtype: "Field",
       text: "<effect=Continuous-like>Defense Position monsters gain 500 DEF.</effect>"
    },
    Pandemonium: {
+      id: "94585852",
       cardType: SPELL,
       levelOrSubtype: "Field",
       text: '<effect=Continuous-like>Neither player has to pay Life Points during the Standby Phase for "Archfiend" monsters.</effect> <effect=Trigger-like>If an "Archfiend" monster(s) is destroyed and sent to the Graveyard (except by battle): that player can add 1 "Archfiend" monster from their Deck to the hand with a lower Level than the destroyed monster\'s.</effect>'
    },
    Necrovalley: {
+      id: "47355498",
       cardType: SPELL,
       levelOrSubtype: "Field",
       text: '<effect=Continuous-like>All "Gravekeeper\'s" monsters gain 500 ATK and DEF.</effect> <effect=Continuous-like>Cards in the Graveyard cannot be banished.</effect> <effect=Continuous-like>Negate any card effect that would move a card in the Graveyard, other than itself, to a different place.</effect> <effect=Continuous-like>Negate any card effect that changes Types or Attributes in the Graveyard.</effect>'

--- a/web-app/src/databases/cardDB/spells/normalSpells.js
+++ b/web-app/src/databases/cardDB/spells/normalSpells.js
@@ -2,6 +2,7 @@ import { SPELL, RANDOM_DISCARD, HERO, VILLAIN, SPELL_TRAP, SEARCH_DECK } from "u
 
 const normalSpells = {
    "Jade Insect Whistle": {
+      id: "95214051",
       cardType: SPELL,
       levelOrSubtype: "Normal",
       text: "Your opponent places 1 Insect monster from their Deck on top of their Deck.",
@@ -22,6 +23,7 @@ const normalSpells = {
       }
    },
    "The Inexperienced Spy": {
+      id: "81820689",
       cardType: SPELL,
       levelOrSubtype: "Normal",
       text: "Look at 1 random card in your opponent's hand.",
@@ -35,166 +37,197 @@ const normalSpells = {
       }
    },
    "Final Countdown": {
+      id: "95308449",
       cardType: SPELL,
       levelOrSubtype: "Normal",
       text: "Pay 2000 Life Points. <effect=Lingering>After 20 turns have passed (counting the turn you activate this card as the 1st turn), you win the Duel.</effect>",
       prepopLP: { hero: -2000 }
    },
    "Blue Medicine": {
+      id: "20871001",
       cardType: SPELL,
       levelOrSubtype: "Normal",
       text: "Gain 400 Life Points.",
       prepopLP: { hero: 400 }
    },
    "Dian Keto the Cure Master": {
+      id: "84257639",
       cardType: SPELL,
       levelOrSubtype: "Normal",
       text: "Gain 1000 Life Points.",
       prepopLP: { hero: 1000 }
    },
    "Goblin Thief": {
+      id: "45311864",
       cardType: SPELL,
       levelOrSubtype: "Normal",
       text: "Inflict 500 damage to your opponent and gain 500 LP.",
       prepopLP: { hero: 500, villain: -500 }
    },
    Hinotama: {
+      id: "46130346",
       cardType: SPELL,
       levelOrSubtype: "Normal",
       text: "Inflict 500 damage to your opponent.",
       prepopLP: { villain: -500 }
    },
    Ookazi: {
+      id: "19523799",
       cardType: SPELL,
       levelOrSubtype: "Normal",
       text: "Inflict 800 damage to your opponent.",
       prepopLP: { villain: -800 }
    },
    Raimei: {
+      id: "56260110",
       cardType: SPELL,
       levelOrSubtype: "Normal",
       text: "Inflict 300 damage to your opponent.",
       prepopLP: { villain: -300 }
    },
    "Red Medicine": {
+      id: "38199696",
       cardType: SPELL,
       levelOrSubtype: "Normal",
       text: "Gain 500 Life Points.",
       prepopLP: { hero: 500 }
    },
    "Tremendous Fire": {
+      id: "46918794",
       cardType: SPELL,
       levelOrSubtype: "Normal",
       text: "Take 500 damage and inflict 1000 damage to your opponent.",
       prepopLP: { hero: -500, villain: -1000 }
    },
    "A Wingbeat of Giant Dragon": {
+      id: "28596933",
       cardType: SPELL,
       levelOrSubtype: "Normal",
       text: "Return 1 Level 5 or higher Dragon-Type monster you control to the hand, and if you do, destroy all Spell and Trap Cards on the field."
    },
    "Acid Rain": {
+      id: "21323861",
       cardType: SPELL,
       levelOrSubtype: "Normal",
       text: "Destroy all face-up Machine monsters on the field."
    },
    "Amazoness Spellcaster": {
+      id: "81325903",
       cardType: SPELL,
       levelOrSubtype: "Normal",
       text: 'Target 1 "Amazoness" monster you control and 1 face-up monster your opponent controls; switch the original ATK of those targets until the end of this turn.'
    },
    "Block Attack": {
+      id: "25880422",
       cardType: SPELL,
       levelOrSubtype: "Normal",
       text: "Target 1 face-up Attack Position monster your opponent controls; change that target to face-up Defense Position."
    },
    "Book of Taiyou": {
+      id: "38699854",
       cardType: SPELL,
       levelOrSubtype: "Normal",
       text: "Target 1 face-down monster on the field; change that target to face-up Attack Position."
    },
    "Dark-Piercing Light": {
+      id: "45895206",
       cardType: SPELL,
       levelOrSubtype: "Normal",
       text: "If your opponent controls a face-down Defense Position monster(s): Change all face-down Defense Position monsters your opponent controls to face-up Defense Position."
    },
    "Double Snare": {
+      id: "03682106",
       cardType: SPELL,
       levelOrSubtype: "Normal",
       text: "Target 1 face-up card on the field whose effect includes negating Traps' effects; destroy that target."
    },
    "Eternal Rest": {
+      id: "95051344",
       cardType: SPELL,
       levelOrSubtype: "Normal",
       text: "Destroy all equipped monsters."
    },
    "Fengsheng Mirror": {
+      id: "37406863",
       cardType: SPELL,
       levelOrSubtype: "Normal",
       text: "Look at your opponent's hand and discard 1 Spirit monster from their hand (if any)."
    },
    "Giant Trunade": {
+      id: "42703248",
       cardType: SPELL,
       levelOrSubtype: "Normal",
       text: "Return all Spell and Trap Cards on the field to the hand."
    },
    "Gravedigger Ghoul": {
+      id: "82542267",
       cardType: SPELL,
       levelOrSubtype: "Normal",
       text: "Target up to 2 monsters in your opponent's Graveyard; banish them."
    },
    "Gryphon's Feather Duster": {
+      id: "34370473",
       cardType: SPELL,
       levelOrSubtype: "Normal",
       text: "Destroy all other Spells and Traps you control, and if you do, gain 500 Life Points for each card destroyed."
    },
    "Mind Control": {
+      id: "37520316",
       cardType: SPELL,
       levelOrSubtype: "Normal",
       text: "Target 1 monster your opponent controls; until the End Phase, take control of that target, but it cannot declare an attack or be Tributed."
    },
    "Restructer Revolution": {
+      id: "99518961",
       cardType: SPELL,
       levelOrSubtype: "Normal",
       text: "Inflict 200 damage to your opponent for each card in their hand."
    },
    "Secret Pass to the Treasures": {
+      id: "77876207",
       cardType: SPELL,
       levelOrSubtype: "Normal",
       text: "Target 1 face-up monster you control with 1000 or less ATK; That face-up monster can attack directly this turn"
    },
    "Spirit Elimination": {
+      id: "69832741",
       cardType: SPELL,
       levelOrSubtype: "Normal",
       text: "Until the End Phase, if a monster(s) in the Graveyard would be banished: Banish an equal number of monsters on your side of the field instead."
    },
    "Thousand EnerGraveyard": {
+      id: "undefined",
       cardType: SPELL,
       levelOrSubtype: "Normal",
       text: "Face-up Level 2 Normal Monsters (except Tokens) you control gain 1000 ATK/DEF until the End Phase. Destroy all face-up Level 2 Normal Monsters you control during the End Phase."
    },
    Timidity: {
+      id: "40350910",
       cardType: SPELL,
       levelOrSubtype: "Normal",
       text: "Neither player can destroy Set Spells/Traps until your opponent's next End Phase."
    },
    "Token Thanksgiving": {
+      id: "57182235",
       cardType: SPELL,
       levelOrSubtype: "Normal",
       text: "Destroy all tokens on the field, and if you do, gain 800 Life Points for each token destroyed."
    },
    "Triangle Power": {
+      id: "32298781",
       cardType: SPELL,
       levelOrSubtype: "Normal",
       text: "Face-up Level 1 Normal Monsters (except Tokens) you control gain 2000 ATK/DEF until the End Phase. Destroy all face-up Level 2 Normal Monsters you control during the End Phase."
    },
    "Hieroglyph Lithograph": {
+      id: "10248192",
       cardType: SPELL,
       levelOrSubtype: "Normal",
       text: "<effect=Lingering>Pay 1000 Life Points; during this Duel, your hand size limit becomes 7.</effect>",
       prepopLP: { hero: -1000 }
    },
    "Upstart Goblin": {
+      id: "70368879",
       cardType: SPELL,
       levelOrSubtype: "Normal",
       text: "Draw 1 card, then your opponent gains 1000 Life Points.",
@@ -202,18 +235,21 @@ const normalSpells = {
       limit: 2
    },
    "Pot of Greed": {
+      id: "55144522",
       cardType: SPELL,
       levelOrSubtype: "Normal",
       text: "Draw 2 cards.",
       limit: 1
    },
    "Graceful Charity": {
+      id: "79571449",
       cardType: SPELL,
       levelOrSubtype: "Normal",
       text: "Draw 3 cards, then discard 2 cards.",
       limit: 1
    },
    "Delinquent Duo": {
+      id: "44763025",
       cardType: SPELL,
       levelOrSubtype: "Normal",
       text: "Pay 1000 Life Points; your opponent discards 1 random card, and if they have any other cards in their hand, discard 1 more card of their choice.",
@@ -228,34 +264,40 @@ const normalSpells = {
       limit: 1
    },
    "Heavy Storm": {
+      id: "19613556",
       cardType: SPELL,
       levelOrSubtype: "Normal",
       text: "Destroy all Spell and Trap Cards on the field.",
       limit: 1
    },
    Metamorphosis: {
+      id: "46411259",
       cardType: SPELL,
       levelOrSubtype: "Normal",
       text: "Tribute 1 monster; Special Summon 1 Fusion Monster from your Extra Deck with the same Level as the Tributed monster."
    },
    "Nobleman of Crossout": {
+      id: "71044499",
       cardType: SPELL,
       levelOrSubtype: "Normal",
       text: "Target 1 face-down monster on the field; destroy that target, and if you do, banish it, then, if it was a Flip monster, each player banishes all cards from their Deck with that monster's name.",
       limit: 2
    },
    "Creature Swap": {
+      id: "31036355",
       cardType: SPELL,
       levelOrSubtype: "Normal",
       text: "Each player chooses 1 monster they control and switches control of those monsters with each other. Those monsters cannot change their battle positions for the rest of this turn.",
       limit: 2
    },
    "Smashing Ground": {
+      id: "97169186",
       cardType: SPELL,
       levelOrSubtype: "Normal",
       text: "Destroy the 1 face-up monster your opponent controls that has the highest DEF (your choice, if tied)."
    },
    "Reinforcement of the Army": {
+      id: "32807846",
       cardType: SPELL,
       levelOrSubtype: "Normal",
       text: "Add 1 Level 4 or lower Warrior monster from your Deck to your hand.",
@@ -280,6 +322,7 @@ const normalSpells = {
       limit: 2
    },
    "Stamping Destruction": {
+      id: "81385346",
       cardType: SPELL,
       levelOrSubtype: "Normal",
       text: "If you control a Dragon monster: Target 1 Spell/Trap on the field; destroy that target, and if you do, inflict 500 damage to its controller."

--- a/web-app/src/databases/cardDB/spells/quickplaySpells.js
+++ b/web-app/src/databases/cardDB/spells/quickplaySpells.js
@@ -2,12 +2,14 @@ import { SPELL, HERO, TOKENS, SPELL_TRAP } from "utils/constants.js";
 
 const quickplaySpells = {
    "Mystical Space Typhoon": {
+      id: "05318639",
       cardType: SPELL,
       levelOrSubtype: "Quick-Play",
       text: "Target 1 Spell/Trap on the field; destroy that target.",
       limit: 1
    },
    Scapegoat: {
+      id: "73915051",
       cardType: SPELL,
       levelOrSubtype: "Quick-Play",
       text: 'Special Summon 4 "Sheep Tokens" (Beast/EARTH/Level 1/ATK 0/DEF 0) in Defense Position. They cannot be Tributed for a Tribute Summon. You cannot Summon other monsters the turn you activate this card (but you can Normal Set).',
@@ -25,16 +27,19 @@ const quickplaySpells = {
       }
    },
    "Book of Moon": {
+      id: "14087893",
       cardType: SPELL,
       levelOrSubtype: "Quick-Play",
       text: "Target 1 face-up monster on the field; change that target to face-down Defense Position."
    },
    "Soul Reversal": {
+      id: "78864369",
       cardType: SPELL,
       levelOrSubtype: "Quick-Play",
       text: "Target 1 Flip monster in your Graveyard; add that target to the top of the Deck."
    },
    "The Reliable Guardian": {
+      id: "16430187",
       cardType: SPELL,
       levelOrSubtype: "Quick-Play",
       text: "Target 1 face-up monster on the field; it gains 700 DEF until the end of this turn."

--- a/web-app/src/databases/cardDB/traps/continuousTraps.js
+++ b/web-app/src/databases/cardDB/traps/continuousTraps.js
@@ -2,81 +2,97 @@ import { TRAP, VILLAIN, SPELL_TRAP, RANDOM_DISCARD } from "utils/constants.js";
 
 const continuousTraps = {
    "Astral Barrier": {
+      id: "37053871",
       cardType: TRAP,
       levelOrSubtype: "Continuous",
       text: "<effect=Trigger-like>If your opponent's monster attacks a monster you control: You can make the attack a direct attack instead.</effect>"
    },
    "Bad Reaction to Simochi": {
+      id: "40633297",
       cardType: TRAP,
       levelOrSubtype: "Continuous",
       text: "<effect=Continuous-like>Any effect that would make your opponent gain Life Points inflicts the same amount of damage to them, instead.</effect>"
    },
    "Bottomless Shifting Sand": {
+      id: "76532077",
       cardType: TRAP,
       levelOrSubtype: "Continuous",
       text: "<effect=Trigger-like>Once per turn, during your opponent's End Phase: Destroy the face-up monster(s) on the field with the highest ATK.</effect> <effect=Continuous-like>During your Standby Phase, if you have 4 or less cards in your hand, destroy this card.</effect>"
    },
    "Des Counterblow": {
+      id: "39131963",
       cardType: TRAP,
       levelOrSubtype: "Continuous",
       text: "<effect=Trigger-like>When a monster inflicts battle damage by a direct attack: Destroy that monster.</effect>"
    },
    "Dragon Capture Jar": {
+      id: "50045299",
       cardType: TRAP,
       levelOrSubtype: "Continuous",
       text: "<effect=Continuous-like>Change all face-up Dragon-Type monsters on the field to Defense Position, also they cannot change their battle positions.</effect>"
    },
    "Enervating Mist": {
+      id: "26022485",
       cardType: TRAP,
       levelOrSubtype: "Continuous",
       text: "<effect=Continuous-like>Your opponent's hand size limit becomes 5.</effect>"
    },
    "Fatal Abacus": {
+      id: "77910045",
       cardType: TRAP,
       levelOrSubtype: "Continuous",
       text: "<effect=Continuous-like>When a monster(s) is sent from the field to the Graveyard: Inflict 500 damage per card to its owner.</effect>"
    },
    "Graverobber's Retribution": {
+      id: "33737664",
       cardType: TRAP,
       levelOrSubtype: "Continuous",
       text: "<effect=Trigger-like>Once per turn, during your Standby Phase: Your opponent takes 100 damage for each of their banished monsters.</effect>"
    },
    "Gravity Bind": {
+      id: "85742772",
       cardType: TRAP,
       levelOrSubtype: "Continuous",
       text: "<effect=Continuous-like>Level 4 or higher monsters cannot attack.</effect>"
    },
    "Infinite Dismissal": {
+      id: "54109233",
       cardType: TRAP,
       levelOrSubtype: "Continuous",
       text: "<effect=Trigger-like>Once per turn, during the End Phase: Destroy all Level 3 or lower monsters that were Normal or Flip Summoned this turn.</effect>"
    },
    "Jam Defender": {
+      id: "21558682",
       cardType: TRAP,
       levelOrSubtype: "Continuous",
       text: '<effect=Trigger-like>When an opponent\'s monster declares an attack on a monster you control: You can target 1 "Revival Jam" you control; switch the attack target to that target.</effect>'
    },
    "Life Absorbing Machine": {
+      id: "14318794",
       cardType: TRAP,
       levelOrSubtype: "Continuous",
       text: "<effect=Trigger-like>Once per turn, during your Standby Phase: Gain Life Points equal to half the total Life Points you paid during your last turn.</effect>"
    },
    "Ninjitsu Art of Decoy": {
+      id: "89628781",
       cardType: TRAP,
       levelOrSubtype: "Continuous",
       text: '<effect=Continuous-like>Target 1 face-up "Ninja" monster you control; it cannot be destroyed by battle.</effect>'
    },
    "Pyramid of Light": {
+      id: "53569894",
       cardType: TRAP,
       levelOrSubtype: "Continuous",
       text: '<effect=Continuous-like>If this face-up card leaves the field, destroy "Andro Sphinx" and "Sphinx Teleia" on your side of the field, and if you do, banish them.</effect>'
    },
    "Respect Play": {
+      id: "08951260",
       cardType: TRAP,
       levelOrSubtype: "Continuous",
       text: "<effect=Continuous-like>The turn player must play with their hand revealed.</effect>"
    },
    "Robbin' Goblin": {
+      id: "88279736",
       cardType: TRAP,
       levelOrSubtype: "Continuous",
       text: "<effect=Trigger-like>If your monster inflicts Battle Damage to your opponent: Discard 1 random card from their hand.</effect>",
@@ -89,50 +105,59 @@ const continuousTraps = {
       }
    },
    "Robbin' Zombie": {
+      id: "83258273",
       cardType: TRAP,
       levelOrSubtype: "Continuous",
       text: "<effect=Trigger-like>If your monster inflicts Battle Damage to your opponent: Send the top card of their Deck to the Graveyard.</effect>"
    },
    "Royal Oppression": {
+      id: "93016201",
       cardType: TRAP,
       levelOrSubtype: "Continuous",
       text: "<effect=Quick-like>If a monster would be Special Summoned or an effect that Special Summons a monster(s) is activated (except during Damage Step): Either player may pay 800 Life Points; negate the Summon or activation, and if you do, destroy that card.</effect>",
       prepopLP: { hero: -800, villain: -800 }
    },
    "Shadow Spell": {
+      id: "29267084",
       cardType: TRAP,
       levelOrSubtype: "Continuous",
       text: "<effect=Continuous-like>Activate this card by targeting 1 face-up monster your opponent controls; it loses 700 ATK, also it cannot attack or change its battle position.</effect> <effect=Continuous-like>When it leaves the field, destroy this card.</effect>"
    },
    "Skill Drain": {
+      id: "82732705",
       cardType: TRAP,
       levelOrSubtype: "Continuous",
       text: "Activate by paying 1000 Life Points. <effect=Continuous-like>The effects of all face-up monsters on the field are negated while those monsters are face-up on the field (but their effects can still be activated).</effect>",
       prepopLP: { hero: -1000 }
    },
    "Skull Lair": {
+      id: "06733059",
       cardType: TRAP,
       levelOrSubtype: "Continuous",
       text: "<effect=Quick-like>You can target 1 face-up monster on the field, then banish monsters from your Graveyard equal to its Level; destroy that face-up monster.</effect>"
    },
    "The Emperor's Holiday": {
+      id: "68400115",
       cardType: TRAP,
       levelOrSubtype: "Continuous",
       text: "<effect=Continuous-like>Negate the effects of all Equip Spells.</effect>"
    },
    "Type Zero Magic Crusher": {
+      id: "21237481",
       cardType: TRAP,
       levelOrSubtype: "Continuous",
       text: "<effect=Quick-like>You can discard 1 Spell; inflict 500 damage to your opponent.</effect>",
       prepopLP: { villain: -500 }
    },
    "Call of the Haunted": {
+      id: "97077563",
       cardType: TRAP,
       levelOrSubtype: "Continuous",
       text: "Activate this card by targeting 1 monster in your Graveyard; Special Summon that target in Attack Position. <effect=Continuous-like>When this card leaves the field, destroy that monster.</effect> <effect=Continuous-like>When that monster is destroyed, destroy this card.</effect>",
       limit: 1
    },
    "Royal Decree": {
+      id: "51452091",
       cardType: TRAP,
       levelOrSubtype: "Continuous",
       text: "<effect=Continuous-like>Negate all other Trap effects on the field.</effect>"

--- a/web-app/src/databases/cardDB/traps/counterTraps.js
+++ b/web-app/src/databases/cardDB/traps/counterTraps.js
@@ -2,6 +2,7 @@ import { TRAP } from "utils/constants.js";
 
 const counterTraps = {
    "Solemn Judgment": {
+      id: "41420027",
       cardType: TRAP,
       levelOrSubtype: "Counter",
       text: "When a monster(s) would be Summoned, OR a Spell/Trap Card is activated: Pay half your Life Points; negate the Summon or activation, and if you do, destroy that card.",

--- a/web-app/src/databases/cardDB/traps/normalTraps.js
+++ b/web-app/src/databases/cardDB/traps/normalTraps.js
@@ -2,6 +2,7 @@ import { TRAP, VILLAIN, SEARCH_DECK, SPELL_TRAP } from "utils/constants.js";
 
 const normalTraps = {
    "Arsenal Robber": {
+      id: "55348096",
       cardType: TRAP,
       levelOrSubtype: "Normal",
       text: "Your opponent selects 1 Equip Spell Card from his/her Deck and sends it to the Graveyard.",
@@ -20,197 +21,235 @@ const normalTraps = {
       }
    },
    "Return from the Different Dimension": {
+      id: "27174286",
       cardType: TRAP,
       levelOrSubtype: "Normal",
       text: "Pay half your Life Points; Special Summon as many of your banished monsters as possible. During the End Phase, banish all monsters that were Special Summoned by this effect.",
       prepopLP: { hero: "half" }
    },
    "Destruction Ring": {
+      id: "21219755",
       cardType: TRAP,
       levelOrSubtype: "Normal",
       text: "Target 1 face-up monster you control; destroy that face-up monster, and if you do, each player takes 1000 damage.",
       prepopLP: { hero: -1000, villain: -1000 }
    },
    "A Feint Plan": {
+      id: "68170903",
       cardType: TRAP,
       levelOrSubtype: "Normal",
       text: "Face-down monsters cannot be attacked this turn."
    },
    "Acid Trap Hole": {
+      id: "41356845",
       cardType: TRAP,
       levelOrSubtype: "Normal",
       text: "Target 1 face-down Defense Position monster on the field; flip it face-up, then destroy it if its DEF is 2000 or less, or return it face-down if its DEF is more than 2000."
    },
    "Assault on GHQ": {
+      id: "62633180",
       cardType: TRAP,
       levelOrSubtype: "Normal",
       text: "Target 1 monster you control; destroy that monster, then send 2 cards from the top of your opponent's Deck to the Graveyard."
    },
    "Beast Soul Swap": {
+      id: "35149085",
       cardType: TRAP,
       levelOrSubtype: "Normal",
       text: "Target 1 Beast monster you control; return it to the hand, and if you do, Special Summon 1 Beast-Type monster from your hand with the same Level as the monster that was returned to the hand."
    },
    "Castle Walls": {
+      id: "44209392",
       cardType: TRAP,
       levelOrSubtype: "Normal",
       text: "Target 1 face-up monster on the field; it gains 500 DEF until the end of this turn."
    },
    "Compulsory Evacuation Device": {
+      id: "94192409",
       cardType: TRAP,
       levelOrSubtype: "Normal",
       text: "Target 1 monster on the field; return that target to the hand."
    },
    "D.D. Dynamite": {
+      id: "08628798",
       cardType: TRAP,
       levelOrSubtype: "Normal",
       text: "Inflict 300 damage to your opponent for each of their banished cards."
    },
    "Desert Sunlight": {
+      id: "93747864",
       cardType: TRAP,
       levelOrSubtype: "Normal",
       text: "If you control a face-down Defense Position monster(s) or face-up Attack Position monster(s): Change all monsters you control to face-up Defense Position."
    },
    Disappear: {
+      id: "24623598",
       cardType: TRAP,
       levelOrSubtype: "Normal",
       text: "Target 1 card in your opponent's Graveyard; banish that target."
    },
    Disarmament: {
+      id: "20727787",
       cardType: TRAP,
       levelOrSubtype: "Normal",
       text: "Destroy all Equip Cards on the field."
    },
    Earthshaker: {
+      id: "60866277",
       cardType: TRAP,
       levelOrSubtype: "Normal",
       text: "Declare 2 monster Attributes; your opponent chooses 1 of them and destroys all monsters on the field with that Attribute."
    },
    "EnerGraveyard Drain": {
+      id: "undefined",
       cardType: TRAP,
       levelOrSubtype: "Normal",
       text: "Target 1 face-up monster you control; until the end of this turn, it gains 200 ATK/DEF for each card in your opponent's hand."
    },
    "Exhausting Spell": {
+      id: "95451366",
       cardType: TRAP,
       levelOrSubtype: "Normal",
       text: "Remove all Spell Counters on the field."
    },
    "Fiend's Hand Mirror": {
+      id: "58607704",
       cardType: TRAP,
       levelOrSubtype: "Normal",
       text: "When your opponent activates a Spell that targets exactly 1 Spell/Trap (and no other cards) on the field: Target another card that would be an appropriate target; that Spell now targets the new target."
    },
    "Gift of The Mystical Elf": {
+      id: "98299011",
       cardType: TRAP,
       levelOrSubtype: "Normal",
       text: "Gain 300 Life Points for each monster on the field."
    },
    Graverobber: {
+      id: "61705417",
       cardType: TRAP,
       levelOrSubtype: "Normal",
       text: "Target 1 Spell in your opponent's Graveyard; add it to your hand. If you use it, take 2000 damage immediately after. During the end phase, if you did not use it, send it to the Graveyard.",
       prepopLP: { hero: -2000 }
    },
    "Interdimensional Matter Transporter": {
+      id: "36261276",
       cardType: TRAP,
       levelOrSubtype: "Normal",
       text: "Target 1 face-up monster you control; banish that target until the End Phase."
    },
    Meteorain: {
+      id: "64274292",
       cardType: TRAP,
       levelOrSubtype: "Normal",
       text: "This turn, monsters you control inflict piercing battle damage to your opponent."
    },
    "Mind Crush": {
+      id: "15800838",
       cardType: TRAP,
       levelOrSubtype: "Normal",
       text: "Declare 1 card name; look at your opponent's hand, then discard all copies of it, otherwise you discard 1 random card."
    },
    "Pikeru's Circle of Enchantment": {
+      id: "74270067",
       cardType: TRAP,
       levelOrSubtype: "Normal",
       text: "You take no damage from card effects this turn."
    },
    "Really Eternal Rest": {
+      id: "28121403",
       cardType: TRAP,
       levelOrSubtype: "Normal",
       text: "Destroy all equipped monsters."
    },
    "Solar Ray": {
+      id: "44472639",
       cardType: TRAP,
       levelOrSubtype: "Normal",
       text: "Inflict 600 damage to your opponent for each face-up LIGHT monster you control."
    },
    "The Spell Absorbing Life": {
+      id: "99517131",
       cardType: TRAP,
       levelOrSubtype: "Normal",
       text: "If a face-down Defense Position monster or an Effect Monster is on the field: Change all face-down Defense Position monsters on the field to face-up Defense Position (Flip monsters' effects are not activated at this time), also gain 400 Life Points for each Effect Monster on the field."
    },
    "Threatening Roar": {
+      id: "36361633",
       cardType: TRAP,
       levelOrSubtype: "Normal",
       text: "Your opponent cannot declare an attack this turn."
    },
    "Two-Pronged Attack": {
+      id: "83887306",
       cardType: TRAP,
       levelOrSubtype: "Normal",
       text: "Target 2 monsters you control and 1 monster your opponent controls; destroy those targets."
    },
    "Windstorm of Etaqua": {
+      id: "59744639",
       cardType: TRAP,
       levelOrSubtype: "Normal",
       text: "Change the battle positions of all face-up monsters your opponent controls."
    },
    "Zero Gravity": {
+      id: "83133491",
       cardType: TRAP,
       levelOrSubtype: "Normal",
       text: "Change the battle positions of all face-up monsters on the field."
    },
    "Mirror Force": {
+      id: "44095762",
       cardType: TRAP,
       levelOrSubtype: "Normal",
       text: "When an opponent's monster declares an attack: Destroy all your opponent's Attack Position monsters.",
       limit: 1
    },
    "Torrential Tribute": {
+      id: "53582587",
       cardType: TRAP,
       levelOrSubtype: "Normal",
       text: "When a monster(s) is Summoned: Destroy all monsters on the field.",
       limit: 1
    },
    "Ring of Destruction": {
+      id: "83555666",
       cardType: TRAP,
       levelOrSubtype: "Normal",
       text: "Target 1 face-up monster; destroy that face-up monster, and if you do, inflict damage to both players equal to that target's ATK.",
       limit: 1
    },
    "Sakuretsu Armor": {
+      id: "56120475",
       cardType: TRAP,
       levelOrSubtype: "Normal",
       text: "When an opponent's monster declares an attack: Target the attacking monster; destroy that target."
    },
    "Dust Tornado": {
+      id: "60082869",
       cardType: TRAP,
       levelOrSubtype: "Normal",
       text: "Target 1 Spell/Trap your opponent controls; destroy that target, then you can Set 1 Spell/Trap from your hand."
    },
    "Trap Dustshoot": {
+      id: "64697231",
       cardType: TRAP,
       levelOrSubtype: "Normal",
       text: "Activate only if your opponent has 4 or more cards in their hand. Look at your opponent's hand, select 1 Monster Card in it, and return that card to its owner's Deck."
    },
    "Jar of Greed": {
+      id: "83968380",
       cardType: TRAP,
       levelOrSubtype: "Normal",
       text: "Draw 1 card."
    },
    "Raigeki Break": {
+      id: "04178474",
       cardType: TRAP,
       levelOrSubtype: "Normal",
       text: "Discard 1 card, then target 1 card on the field; destroy it."
    },
    "Widespread Ruin": {
+      id: "77754944",
       cardType: TRAP,
       levelOrSubtype: "Normal",
       text: "When an opponent's monster declares an attack: Destroy the Attack Position monster your opponent controls with the highest ATK (your choice, if tied)."


### PR DESCRIPTION
YDK serial number ids harvested from DuelingBook: https://gist.github.com/scheibo/19b9841fa37bd898d984a0025c6d9a27

I used the following script to then add the ids to the card DB:

```js
const fs = require('fs');
const YDK = require('../source/ydk.json');

const RE = /^   "?(\w.*?)"?: {$/;

const file = fs.readFileSync(process.argv[2], 'utf8');
const buf = [];
for (const line of file.split('\n')) {
  buf.push(line);
  const m = RE.exec(line);
  if (m) buf.push(`      id: "${YDK[m[1]]}",`);
}
fs.writeFileSync(process.argv[2], buf.join('\n'));
```

This is necessary for #221 
