### PR TITLE
Add ability to disable card foil in settings

### DIFF
--- a/web-app/src/components/Switches/Foil.js
+++ b/web-app/src/components/Switches/Foil.js
@@ -1,0 +1,32 @@
+import React, { PureComponent } from "react";
+
+import Switch from "@material-ui/core/Switch";
+
+class Foil extends PureComponent {
+   constructor(props) {
+      super(props);
+
+      const storage = window.localStorage;
+      if (storage.getItem("foilOn") === null) storage.setItem("foilOn", true);
+
+      this.state = { foilOn: storage.getItem("foilOn") === "true" };
+   }
+
+   flipFoil = (event) => {
+      window.localStorage.setItem("foilOn", event.target.checked);
+      this.setState({ foilOn: event.target.checked });
+   };
+
+   render() {
+      const { foilOn } = this.state;
+
+      return (
+         <div>
+            <Switch checked={foilOn} onChange={this.flipFoil} color="primary" style={{ color: "#9c27b0" }} />
+            Foil {foilOn ? "On" : "Off"}
+         </div>
+      );
+   }
+}
+
+export default Foil;

--- a/web-app/src/components/YugiohCard/CardArt.js
+++ b/web-app/src/components/YugiohCard/CardArt.js
@@ -20,6 +20,10 @@ class CardArt extends PureComponent {
       } else return <img src={"/cards/svgs/subtypes/" + levelOrSubtype + ".svg"} draggable="false" height={nameHeight * 0.8} alt="yugioh subtype" />;
    };
 
+   foilOn() {
+      return window.localStorage.getItem("foilOn") === "true";
+   }
+
    render() {
       const { classes, name, nameHeight, cardTypeIcon, levelOrSubtype, atk, def, showNames, villExtension, battle } = this.props;
       const isMonster = !isNaN(levelOrSubtype);
@@ -32,7 +36,9 @@ class CardArt extends PureComponent {
                      <img src={"/battle/" + battle + ".png"} className={classes.battleImg} alt={battle} />
                   </div>
                )}
+            {this.foilOn() && (
                <FoilStars nameHeight={nameHeight} />
+            )}
             </div>
             {showNames && (
                <div className={classes["name" + villExtension]} style={{ fontSize: nameHeight + "px", lineHeight: nameHeight + "px" }}>

--- a/web-app/src/views/SettingsPage/SettingsPage.js
+++ b/web-app/src/views/SettingsPage/SettingsPage.js
@@ -15,6 +15,7 @@ import CardForm from "components/Card/CardForm.js";
 import CardBody from "components/Card/CardBody.js";
 import CardHeader from "components/Card/CardHeader.js";
 import CardFooter from "components/Card/CardFooter.js";
+import Foil from "components/Switches/Foil.js";
 
 import { isDiscordValid, formatFileName } from "./utils.js";
 import setBodyImage from "utils/setBodyImage.js";
@@ -186,6 +187,11 @@ class SettingsPage extends PureComponent {
                            <JustSleeves height={250} sleeves={sleeves} />
                         </div>
                      </div>
+                  </div>
+               </GridItem>
+               <GridItem xs={12}>
+                  <div className={classes.center} style={{ marginBottom: "30px"}}>
+                     <Foil />
                   </div>
                </GridItem>
                <GridItem xs={12} sm={6}>


### PR DESCRIPTION
Shamelessly copied from the `Sound` component. **I'm not sure if this is correct though - we perhaps want to sync this into `settings` as well?**

I'm not entirely sure what the plan is around foil (I assume its just enabled everywhere as a demonstration of the feature). Is the plan to make the foil effect a perk or something that can be earned? Is the idea to implement more types of foil/some sort of card rarity system (in which case, you would probably want to do something similar to #234 and encode the rarity in the card name like how alternative art is handled)?

Regardless of any support for card rarities/perks/etc, I believe being able to opt out of any visual effects on cards is desirable so I think this toggle is still useful.