### PR TITLE
Update mill script to handle failure and generic milling

### DIFF
--- a/Lambda/GameSocket/Mill.js
+++ b/Lambda/GameSocket/Mill.js
@@ -5,12 +5,15 @@ const display = require("./utils/display");
 // @desc Sends a payload to others about a card being milled
 // @access Private
 // @db 1 read, 0 writes
-async function mill(id, username, deck, params, connectionId, api) {
+async function mill(id, username, deck, params, fail, connectionId, api) {
    // This is a really hacky way to check for Merchant vs Reasoning/Gate
    const cardType = params.cardType && params.cardType.operator === "OR" ? "Spell or Trap" : "Normal Summon Monster";
 
-   const message = { author: "Server", content: `${username} milled until a ${cardType} card.` };
-   const action = { action: "MILL_UNTIL", data: { player: username, deck, params } };
+   const content =  fail
+      ? `${username} was unable to mill until a ${cardType} card as there are no legal targets remaining.`
+      : `${username} milled until a ${cardType} card.`;
+   const message = { author: "Server", content };
+   const action = { action: "MILL_UNTIL", data: { player: username, deck, params, fail } };
 
    await actionAndMessage(id, action, message, connectionId, api);
    return { statusCode: 200, body: "Card milled" };

--- a/Lambda/GameSocket/Mill.js
+++ b/Lambda/GameSocket/Mill.js
@@ -6,12 +6,16 @@ const display = require("./utils/display");
 // @access Private
 // @db 1 read, 0 writes
 async function mill(id, username, deck, params, fail, connectionId, api) {
-   // This is a really hacky way to check for Merchant vs Reasoning/Gate
-   const cardType = params.cardType && params.cardType.operator === "OR" ? "Spell or Trap" : "Normal Summon Monster";
-
-   const content =  fail
-      ? `${username} was unable to mill until a ${cardType} card as there are no legal targets remaining.`
-      : `${username} milled until a ${cardType} card.`;
+   let content;
+   if (typeof params === "number") {
+      content = `${username} milled ${params} card${params === 1 ? '' : 's'}.`;
+   } else {
+      // This is a really hacky way to check for Merchant vs Reasoning/Gate
+      const cardType = params.cardType && params.cardType.operator === "OR" ? "Spell or Trap" : "Normal Summon Monster";
+      content =  fail
+         ? `${username} was unable to mill until a ${cardType} card as there are no legal targets remaining.`
+         : `${username} milled until a ${cardType} card.`;
+   }
    const message = { author: "Server", content };
    const action = { action: "MILL_UNTIL", data: { player: username, deck, params, fail } };
 

--- a/Lambda/GameSocket/Mill.js
+++ b/Lambda/GameSocket/Mill.js
@@ -11,7 +11,7 @@ async function mill(id, username, deck, params, fail, connectionId, api) {
       content = `${username} milled ${params} card${params === 1 ? '' : 's'}.`;
    } else {
       // This is a really hacky way to check for Merchant vs Reasoning/Gate
-      const cardType = params.cardType && params.cardType.operator === "OR" ? "Spell or Trap" : "Normal Summon Monster";
+      const cardType = params.text ? "Normal Summon Monster" : "Spell or Trap";
       content =  fail
          ? `${username} was unable to mill until a ${cardType} card as there are no legal targets remaining.`
          : `${username} milled until a ${cardType} card.`;

--- a/Lambda/GameSocket/index.js
+++ b/Lambda/GameSocket/index.js
@@ -64,7 +64,7 @@ exports.handler = async (event) => {
       case "ReorderDeck":
          return await reorderDeck(id, username, data.deck, connectionId, api);
       case "Mill":
-         return await mill(id, username, data.deck, data.params, connectionId, api);
+         return await mill(id, username, data.deck, data.params, data.fail, connectionId, api);
       case "SendSelection":
          return await sendSelection(id, data, connectionId, api);
       case "RemoveSelection":

--- a/web-app/src/databases/cardDB/monsters/effectMonsters.js
+++ b/web-app/src/databases/cardDB/monsters/effectMonsters.js
@@ -1531,6 +1531,42 @@ const effectMonsters = {
          }
       }
    },
+   "Needle Worm": {
+      id: "81843628",
+      cardType: EFFECT_MONSTER,
+      attribute: EARTH,
+      levelOrSubtype: 2,
+      atk: 750,
+      def: 600,
+      text: "Insect/Flip/Effect - <effect=Flip>FLIP: Send the top 5 cards of your opponent's Deck to the Graveyard.</effect>",
+      script: {
+         name: MILL_UNTIL,
+         message: "FIXME",
+         displayCondition: {
+            players: [VILLAIN],
+            row: MONSTER
+         },
+         params: 5
+      }
+    },
+    "Hiro's Shadow Scout": {
+      id: "81863068",
+      cardType: EFFECT_MONSTER,
+      attribute: DARK,
+      levelOrSubtype: 2,
+      atk: 650,
+      def: 500,
+      text: "Fiend/Flip/Effect - <effect=Flip>FLIP: Your opponent draws 3 cards, then they reveal those cards, also they discard any Spell drawn with this effect.</effect>",
+      script: {
+         name: MILL_UNTIL,
+         message: "FIXME",
+         displayCondition: {
+            players: [VILLAIN],
+            row: MONSTER
+         },
+         params: 3
+      }
+   },
    "Abyss Soldier": {
       id: "18318842",
       cardType: EFFECT_MONSTER,

--- a/web-app/src/stateStore/actions/game/scripts.js
+++ b/web-app/src/stateStore/actions/game/scripts.js
@@ -11,18 +11,22 @@ function filterDeck(player, script) {
 }
 
 function millUntil(player, deck, params, socket = false) {
-   if (socket && socket.api) {
-      const payload = { action: MILL, data: { token: socket.token, id: socket.matchId, deck, params } };
-      socket.api.send(JSON.stringify(payload));
-   }
-
    const topCard = deck.length - 1;
    return (dispatch) => {
-      for (let i = topCard, stop = false; i >= 0 && !stop; i--) {
+      let found = -1;
+      for (let i = topCard; i >= 0 && found < 0; i--) {
          const card = deck[i];
          const { fail } = checkParams(card, params);
-         if (fail.length === 0) stop = true;
+         if (fail.length === 0) found = i;
+      }
 
+      if (socket && socket.api) {
+         const payload = { action: MILL, data: { token: socket.token, id: socket.matchId, deck, params, fail: found < 0 } };
+         socket.api.send(JSON.stringify(payload));
+      }
+      if (found < 0) return;
+
+      for (let i = topCard; i >= found; i--) {
          dispatch(moveCard({ from: { player, row: DECK, zone: i }, to: { player, row: GRAVEYARD, zone: 0 }, noSound: i !== topCard }));
       }
    };

--- a/web-app/src/stateStore/actions/game/scripts.js
+++ b/web-app/src/stateStore/actions/game/scripts.js
@@ -14,10 +14,14 @@ function millUntil(player, deck, params, socket = false) {
    const topCard = deck.length - 1;
    return (dispatch) => {
       let found = -1;
-      for (let i = topCard; i >= 0 && found < 0; i--) {
-         const card = deck[i];
-         const { fail } = checkParams(card, params);
-         if (fail.length === 0) found = i;
+      if (typeof params === "number") {
+         found = Math.max(0, deck.length - params);
+      } else {
+         for (let i = topCard; i >= 0 && found < 0; i--) {
+            const card = deck[i];
+            const { fail } = checkParams(card, params);
+            if (fail.length === 0) found = i;
+         }
       }
 
       if (socket && socket.api) {


### PR DESCRIPTION
I'm unable to test the new backend logic, but this doesn't appear to break with any of the existing logic (just might be confusing to the user if they click "Mill Until" and nothing happens without the backend logic to send a message explaining the failure).

Necessary but not sufficient for Reasoning/Monster Gate support.