### PR TITLE
Add script to alphabetize and format db.json

### DIFF
--- a/build.js
+++ b/build.js
@@ -1,14 +1,14 @@
 #!/usr/bin/env node
-'use strict';
+"use strict";
 
-const fs = require('fs');
-const path = require('path');
+const fs = require("fs");
+const path = require("path");
 
-for (const destination of ['Lambda/GameSocket', 'Lambda/LeagueSocket']) {
-  const dst = path.resolve(__dirname, destination, 'shared');
+for (const destination of ["Lambda/GameSocket", "Lambda/LeagueSocket"]) {
+  const dst = path.resolve(__dirname, destination, "shared");
   if (!fs.existsSync(dst)) fs.mkdirSync(dst);
-  for (const file of fs.readdirSync(path.resolve(__dirname, 'shared'))) {
-    if (!file.endsWith('.js') && !file.endsWith('.json')) continue;
-    fs.copyFileSync(path.resolve(__dirname, 'shared', file), path.resolve(dst, file));
+  for (const file of fs.readdirSync(path.resolve(__dirname, "shared"))) {
+    if (!file.endsWith(".js") && !file.endsWith(".json")) continue;
+    fs.copyFileSync(path.resolve(__dirname, "shared", file), path.resolve(dst, file));
   }
 }

--- a/shared/db.json
+++ b/shared/db.json
@@ -968,7 +968,10 @@
       "text": "Both players discard as many cards as possible from their hands, then each player draws the same number of cards they discarded.",
       "script": {
          "name": "DISCARD_AND_DRAW",
-         "displayCondition": { "players": ["HERO", "VILLAIN"], "row": "spellTrap" },
+         "displayCondition": {
+            "players": ["HERO", "VILLAIN"],
+            "row": "spellTrap"
+         },
          "params": "same"
       },
       "limit": 1
@@ -2127,7 +2130,10 @@
       "text": "Fiend/Effect - <effect=Trigger>When this card is sent from the field to the Graveyard: Each player adds 1 Level 3 or lower Normal Monster from their Deck to their hand.</effect>",
       "script": {
          "name": "SEARCH_DECK",
-         "displayCondition": { "players": ["HERO", "VILLAIN"], "row": "graveyard" },
+         "displayCondition": {
+            "players": ["HERO", "VILLAIN"],
+            "row": "graveyard"
+         },
          "params": {
             "levelOrSubtype": { "operator": "<", "value": 3 },
             "cardType": { "value": "normalMonster" }
@@ -3011,7 +3017,9 @@
       "script": {
          "name": "SEARCH_DECK",
          "displayCondition": { "players": ["HERO"], "row": "monster" },
-         "params": { "name": { "operator": "CONTAINS", "value": "Gravekeeper's" } },
+         "params": {
+            "name": { "operator": "CONTAINS", "value": "Gravekeeper's" }
+         },
          "autoClose": true
       }
    },
@@ -4222,7 +4230,9 @@
          "name": "MILL_UNTIL",
          "message": "Spell or Trap",
          "displayCondition": { "players": ["HERO"], "row": "monster" },
-         "params": { "cardType": { "operator": "OR", "value": ["Spell", "Trap"] } }
+         "params": {
+            "cardType": { "operator": "OR", "value": ["Spell", "Trap"] }
+         }
       }
    },
    "Magical Plant Mandragola": {
@@ -4307,17 +4317,10 @@
       "text": "Fairy/Effect – <effect=Trigger>When this card is Normal or Flip Summoned: You can add 1 Ritual Monster or 1 Ritual Spell Card from your Deck to your hand.</effect>",
       "script": {
          "name": "SEARCH_DECK",
-         "displayCondition": {
-            "players": ["HERO"],
-            "row": "monster"
-         },
+         "displayCondition": { "players": ["HERO"], "row": "monster" },
          "params": {
-            "cardType": {
-               "value": "ritualMonster"
-            },
-            "levelOrSubtype": {
-               "value": "Ritual"
-            }
+            "cardType": { "value": "ritualMonster" },
+            "levelOrSubtype": { "value": "Ritual" }
          },
          "oneParam": true,
          "autoClose": true
@@ -4760,7 +4763,10 @@
       "text": "Rock/Flip/Effect – <effect=Trigger>FLIP: Both players discard their entire hands, then draw 5 cards.</effect>",
       "script": {
          "name": "DISCARD_AND_DRAW",
-         "displayCondition": { "players": ["HERO", "VILLAIN"], "row": "monster" },
+         "displayCondition": {
+            "players": ["HERO", "VILLAIN"],
+            "row": "monster"
+         },
          "params": 5
       },
       "limit": 1

--- a/shared/format.js
+++ b/shared/format.js
@@ -1,0 +1,16 @@
+#!/usr/bin/env node
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+
+const stringify = require("@aitodotai/json-stringify-pretty-compact");
+
+const db = require("./db.json");
+
+const sorted = {};
+for (const key of Object.keys(db)) {
+  sorted[key] = db[key];
+}
+
+fs.writeFileSync(path.resolve(__dirname, "db.json"), stringify(sorted, {objectMargins: true, indent: 3}) + "\n");

--- a/shared/package.json
+++ b/shared/package.json
@@ -14,6 +14,7 @@
     "./verifyDeck": "./verifyDeck.js"
   },
   "dependencies": {
+    "@aitodotai/json-stringify-pretty-compact": "^1.3.0",
     "jest": "<27",
     "jest-expect-message": "^1.0.2"
   },
@@ -23,6 +24,7 @@
     ]
   },
   "scripts": {
-    "test": "jest"
+    "test": "jest",
+    "format": "node format"
   }
 }


### PR DESCRIPTION
I believe the diffs to the DB in this PR are only due to the original file having used the default indent (which is 2 spaces) compared to the project indent of 3 spaces (the additional spaces make the lines longer than the default max of 80 characters which causes it to wrap now).

**tl;dr:** I think these parameters will eliminate churn. I think don't need to change anything about your editor, i think the configuration will match whatever transformations your editor was doing. As a bonus, theres now a format script (`npm -C shared format` from the root or `npm format` from `shared`, in both cases after doing `npm -C shared install`) which will allow you to add cards anywhere in the file and then run the format script after to alphabetize it.