### PR TITLE
Fix padding/margins in FieldDivider + focus prepopLP

### DIFF
--- a/web-app/src/assets/jss/material-kit-react/components/lifebarStyle.js
+++ b/web-app/src/assets/jss/material-kit-react/components/lifebarStyle.js
@@ -4,7 +4,7 @@ const container = {
    borderWidth: "2px",
    borderColor: "black",
    borderRadius: "10px",
-   padding: "5px",
+   padding: "2px",
    margin: "3px 10px",
    userSelect: "none",
    width: "25%"

--- a/web-app/src/assets/jss/material-kit-react/views/gameSections/battlefield.js
+++ b/web-app/src/assets/jss/material-kit-react/views/gameSections/battlefield.js
@@ -41,6 +41,11 @@ const battlefieldStyle = {
       flexDirection: "row",
       justifyContent: "center",
       alignItems: "center"
+   },
+   LPinput: {
+      paddingTop: "3px",
+      paddingBottom: "3px",
+      margin: "0 3px"
    }
 };
 

--- a/web-app/src/assets/jss/material-kit-react/views/gameSections/rightTools.js
+++ b/web-app/src/assets/jss/material-kit-react/views/gameSections/rightTools.js
@@ -83,12 +83,6 @@ const rightToolsStyle = {
       backgroundPosition: "50% 40%",
       backgroundImage: 'linear-gradient(rgba(0, 0, 0, 0.85), rgba(0, 0, 0, 0.85)), url("/cards/art/ReinforcementoftheArmy.jpg")'
    },
-   LPbutton: {
-      marginRight: "3px"
-   },
-   LPbox: {
-      marginRight: "3px"
-   },
    inactivePhase: {
       opacity: 0.8
    },

--- a/web-app/src/components/CustomInput/CustomInput.js
+++ b/web-app/src/components/CustomInput/CustomInput.js
@@ -24,6 +24,7 @@ export default function CustomInput(props) {
       error,
       white,
       inputRootCustomClasses,
+      inputCustomClasses,
       success
    } = props;
 
@@ -42,7 +43,8 @@ export default function CustomInput(props) {
    });
    const inputClasses = classNames({
       [classes.input]: true,
-      [classes.whiteInput]: white
+      [classes.whiteInput]: white,
+      [inputCustomClasses]: inputCustomClasses !== undefined
    });
    var formControlClasses;
    if (formControlProps !== undefined) {
@@ -78,6 +80,7 @@ CustomInput.propTypes = {
    inputProps: PropTypes.object,
    formControlProps: PropTypes.object,
    inputRootCustomClasses: PropTypes.string,
+   inputCustomClasses: PropTypes.string,
    error: PropTypes.bool,
    success: PropTypes.bool,
    white: PropTypes.bool,

--- a/web-app/src/components/CustomInput/CustomInput.js
+++ b/web-app/src/components/CustomInput/CustomInput.js
@@ -13,7 +13,7 @@ import styles from "assets/jss/material-kit-react/components/customInputStyle.js
 
 const useStyles = makeStyles(styles);
 
-export default function CustomInput(props) {
+const CustomInput = React.forwardRef((props, ref) => {
    const classes = useStyles();
    const {
       formControlProps,
@@ -59,7 +59,7 @@ export default function CustomInput(props) {
                {labelText}
             </InputLabel>
          ) : null}
-         <Input
+         <Input inputRef={ref}
             classes={{
                input: inputClasses,
                root: marginTop,
@@ -71,7 +71,7 @@ export default function CustomInput(props) {
          />
       </FormControl>
    );
-}
+});
 
 CustomInput.propTypes = {
    labelText: PropTypes.node,
@@ -85,3 +85,5 @@ CustomInput.propTypes = {
    success: PropTypes.bool,
    white: PropTypes.bool,
 };
+
+export default CustomInput;

--- a/web-app/src/views/Game/Battlefield/FieldDivider/LPInputBox.js
+++ b/web-app/src/views/Game/Battlefield/FieldDivider/LPInputBox.js
@@ -15,6 +15,7 @@ class LPInputBox extends PureComponent {
    constructor(props) {
       super(props);
       this.state = { inputLP: "", LPmode: -1 };
+      this.ref = React.createRef();
    }
 
    componentDidUpdate() {
@@ -23,8 +24,10 @@ class LPInputBox extends PureComponent {
 
       const convertedPrepop = prepopLPvalue && (prepopLPvalue === "half" ? Math.floor(lifepoints / 2) : Math.abs(prepopLPvalue));
 
-      if (prepopLPvalue && convertedPrepop !== Number(inputLP))
+      if (prepopLPvalue && convertedPrepop !== Number(inputLP)) {
          this.setState({ inputLP: convertedPrepop, LPmode: prepopLPvalue === "half" || prepopLPvalue < 0 ? -1 : 1 });
+         this.ref.current.focus();
+      }
    }
 
    inputLP = (event) => {
@@ -78,7 +81,7 @@ class LPInputBox extends PureComponent {
 
       return (
          <div>
-            <CustomInput
+            <CustomInput ref={this.ref}
                white
                formControlProps={{ fullWidth: true }}
                inputCustomClasses={classes.LPinput}

--- a/web-app/src/views/Game/Battlefield/FieldDivider/LPInputBox.js
+++ b/web-app/src/views/Game/Battlefield/FieldDivider/LPInputBox.js
@@ -67,7 +67,6 @@ class LPInputBox extends PureComponent {
 
       const LPbutton = (
          <div
-            className={classes.LPbutton}
             onClick={() => {
                this.swapLPmode();
                if (prepopLPvalue) prepopLP(null);
@@ -78,10 +77,11 @@ class LPInputBox extends PureComponent {
       );
 
       return (
-         <div className={classes.LPbox}>
+         <div>
             <CustomInput
                white
                formControlProps={{ fullWidth: true }}
+               inputCustomClasses={classes.LPinput}
                inputProps={{
                   value: inputLP,
                   onChange: this.inputLP,


### PR DESCRIPTION
Seems like you didn't push the most recent change to the field divider so this will probably have conflicts with that, but oh well. Just assume the "after" photo here has arrows and the order swapped around, as that will happen once merged.

![Screen Shot 2021-08-22 at 10 41 20](https://user-images.githubusercontent.com/117249/130364782-7fc4d852-1c5c-4c36-8002-753ba2bb79cb.png)
![Screen Shot 2021-08-22 at 10 41 25](https://user-images.githubusercontent.com/117249/130364777-d32ed2aa-5a15-4701-962a-c27edafe00ab.png)

- gives some breathing room between the tops of the cards and the LP bars
- fixes the margin of the input box so the icon isn't crammed up against it
- fixes the uneven padding within the LP box so that the number being input is actually vertically centered

In addition to these UI polishes, there's also a new feature: selecting cards with `prepopLP` now auto-focuses the LP input box, meaning you can just (for example) click the Duo card and hit 'enter' to subtract 1000 lifepoints as opposed to having to first select the LP input box
