### PR TITLE
Properly plumb through MILL_UNTIL message

### DIFF
--- a/Lambda/GameSocket/Mill.js
+++ b/Lambda/GameSocket/Mill.js
@@ -4,19 +4,17 @@ const actionAndMessage = require("./utils/actionAndMessage.js");
 // @desc Sends a payload to others about a card being milled
 // @access Private
 // @db 1 read, 0 writes
-async function mill(id, username, deck, params, fail, connectionId, api) {
+async function mill(id, username, deck, params, fail, message, connectionId, api) {
    let content;
    if (typeof params === "number") {
       content = `${username} milled ${params} card${params === 1 ? '' : 's'}.`;
    } else {
-      // This is a really hacky way to check for Merchant vs Reasoning/Gate
-      const cardType = params.text ? "Normal Summon Monster" : "Spell or Trap";
-      content =  fail
-         ? `${username} was unable to mill until a ${cardType} card as there are no legal targets remaining.`
-         : `${username} milled until a ${cardType} card.`;
+      content = fail
+         ? `${username} was unable to mill until a ${message} card as there are no legal targets remaining.`
+         : `${username} milled until a ${message} card.`;
    }
    const message = { author: "Server", content };
-   const action = { action: "MILL_UNTIL", data: { player: username, deck, params, fail } };
+   const action = { action: "MILL_UNTIL", data: { player: username, deck, params, fail, message } };
 
    await actionAndMessage(id, action, message, connectionId, api);
    return { statusCode: 200, body: "Card milled" };

--- a/Lambda/GameSocket/index.js
+++ b/Lambda/GameSocket/index.js
@@ -64,7 +64,7 @@ exports.handler = async (event) => {
       case "ReorderDeck":
          return await reorderDeck(id, username, data.deck, connectionId, api);
       case "Mill":
-         return await mill(id, username, data.deck, data.params, data.fail, connectionId, api);
+         return await mill(id, username, data.deck, data.params, data.fail, data.message, connectionId, api);
       case "SendSelection":
          return await sendSelection(id, data, connectionId, api);
       case "RemoveSelection":

--- a/shared/db.json
+++ b/shared/db.json
@@ -3363,7 +3363,6 @@
       "text": "Fiend/Flip/Effect – <effect=Trigger>FLIP: Your opponent draws 3 cards, then they reveal those cards, also they discard any Spell drawn with this effect.</effect>",
       "script": {
          "name": "MILL_UNTIL",
-         "message": "FIXME",
          "displayCondition": { "players": ["VILLAIN"], "row": "monster" },
          "params": 3
       }
@@ -4756,6 +4755,7 @@
       "text": "Tribute 1 monster; excavate cards from the top of your Deck until you excavate a monster that can be Normal Summoned/Set. Special Summon it, also send the other excavated cards to the Graveyard.",
       "script": {
          "name": "MILL_UNTIL",
+         "message": "Normal Summon Monster",
          "displayCondition": { "players": ["HERO"], "row": "spellTrap" },
          "params": {
             "cardType": {
@@ -4988,7 +4988,6 @@
       "text": "Insect/Flip/Effect – <effect=Trigger>FLIP: Send the top 5 cards of your opponent's Deck to the Graveyard.</effect>",
       "script": {
          "name": "MILL_UNTIL",
-         "message": "FIXME",
          "displayCondition": { "players": ["VILLAIN"], "row": "monster" },
          "params": 5
       }
@@ -5816,6 +5815,7 @@
       "text": "Your opponent declares a monster Level from 1 to 12. Excavate cards from the top of your Deck until you excavate a monster that can be Normal Summoned/Set, then, if that monster is the same Level as the one declared by your opponent, send all excavated cards to the Graveyard. If not, Special Summon the excavated monster, also send the remaining cards to the Graveyard.",
       "script": {
          "name": "MILL_UNTIL",
+         "message": "Normal Summon Monster",
          "displayCondition": { "players": ["HERO"], "row": "spellTrap" },
          "params": {
             "cardType": {

--- a/web-app/src/components/CardScript/ScriptButton.js
+++ b/web-app/src/components/CardScript/ScriptButton.js
@@ -44,7 +44,7 @@ class CardScript extends PureComponent {
 
    runScript = () => {
       const { field, activeCard, banishAll, heroPlayer, variant, filterDeck, millUntil, createTokens, discardAndDraw, script } = this.props;
-      const { name, params } = script;
+      const { name, message, params } = script;
       const socket = this.context;
       switch (name) {
          case SEARCH_DECK:
@@ -54,7 +54,7 @@ class CardScript extends PureComponent {
             banishAll(field, heroPlayer, activeCard, variant, socket);
             break;
          case MILL_UNTIL:
-            millUntil(heroPlayer, this.props.field[heroPlayer].deck, params, socket);
+            millUntil(heroPlayer, this.props.field[heroPlayer].deck, params, message, socket);
             break;
          case TOKENS:
             createTokens(heroPlayer, params, socket);

--- a/web-app/src/stateStore/actions/game/scripts.js
+++ b/web-app/src/stateStore/actions/game/scripts.js
@@ -10,7 +10,7 @@ function filterDeck(player, script) {
    return openModal(player, DECK, params, autoClose, oneParam);
 }
 
-function millUntil(player, deck, params, socket = false) {
+function millUntil(player, deck, params, message, socket = false) {
    const topCard = deck.length - 1;
    return (dispatch) => {
       let found = -1;
@@ -25,7 +25,7 @@ function millUntil(player, deck, params, socket = false) {
       }
 
       if (socket && socket.api) {
-         const payload = { action: MILL, data: { token: socket.token, id: socket.matchId, deck, params, fail: found < 0 } };
+         const payload = { action: MILL, data: { token: socket.token, id: socket.matchId, deck, params, fail: found < 0, message } };
          socket.api.send(JSON.stringify(payload));
       }
       if (found < 0) return;

--- a/web-app/src/views/Game/Game.js
+++ b/web-app/src/views/Game/Game.js
@@ -105,8 +105,8 @@ class Game extends Component {
                dispatch(moveCard(data));
                break;
             case MILL_UNTIL: {
-               const { player, deck, params } = data;
-               dispatch(millUntil(player, deck, params));
+               const { player, deck, params, message } = data;
+               dispatch(millUntil(player, deck, params, message));
                break;
             }
             default:


### PR DESCRIPTION
Magical Merchant had a `message` field in its script that confused me when I was adding Hiro/Needle Worm (and left it as FIXME, oops). I think that field was actually meant to be passed to the server to remove the card type detection hack?

**NOT TESTED** - can't deploy the Lambda, so you'll need to verify this works as expected