### PR TITLE
Auto focus script button

### DIFF
--- a/web-app/src/components/CardScript/CardScript.js
+++ b/web-app/src/components/CardScript/CardScript.js
@@ -35,18 +35,19 @@ class CardScript extends PureComponent {
 
       if (!cardName) return null;
 
-      const { cardType, text, script } = getCardDetails(cardName);
+      const { cardType, text, script, prepopLP } = getCardDetails(cardName);
+      const focus = !(prepopLP && (player === heroPlayer ? prepopLP.hero : prepopLP.villain));
 
       return (
          <Fragment>
             {script && this.validScript(activeCard, player, script) && (
-               <ScriptButton script={script} heroPlayer={heroPlayer} cardName={cardName} activeCard={activeCard} />
+               <ScriptButton script={script} heroPlayer={heroPlayer} cardName={cardName} activeCard={activeCard} focus={focus} />
             )}
             {text.includes("/Flip/") && (
-               <ScriptButton script={{ name: BANISH_ALL }} variant="Nobleman of Crossout" activeCard={activeCard} heroPlayer={heroPlayer} />
+               <ScriptButton script={{ name: BANISH_ALL }} variant="Nobleman of Crossout" activeCard={activeCard} heroPlayer={heroPlayer} focus={focus} />
             )}
             {cardType === TRAP && (
-               <ScriptButton script={{ name: BANISH_ALL }} variant="Nobleman of Extermination" activeCard={activeCard} heroPlayer={heroPlayer} />
+               <ScriptButton script={{ name: BANISH_ALL }} variant="Nobleman of Extermination" activeCard={activeCard} heroPlayer={heroPlayer} focus={focus} />
             )}
          </Fragment>
       );

--- a/web-app/src/components/CardScript/ScriptButton.js
+++ b/web-app/src/components/CardScript/ScriptButton.js
@@ -31,15 +31,32 @@ import {
 import { withStyles } from "@material-ui/core/styles";
 import styles from "assets/jss/material-kit-react/components/yugiohCardExpandedStyle.js";
 
-class CardScript extends PureComponent {
+class ScriptButton extends PureComponent {
+   constructor(props) {
+      super(props);
+      this.ref = React.createRef();
+   }
+
    componentDidMount() {
       const { variant, script } = this.props;
 
       if (!variant) bind("s", () => this.runScript(script));
+
+      this.maybeFocus();
+   }
+
+   componentDidUpdate() {
+      this.maybeFocus();
    }
 
    componentWillUnmount() {
       unbind(["s"]);
+   }
+
+   maybeFocus() {
+      const { focus } = this.props;
+
+      if (focus && this.ref.current) this.ref.current.focus();
    }
 
    runScript = () => {
@@ -141,6 +158,7 @@ class CardScript extends PureComponent {
 
       const button = (
          <Button
+            ref={this.ref}
             color="primary"
             onClick={this.runScript}
             style={
@@ -179,16 +197,17 @@ function mapStateToProps(state) {
    return { field: state.field };
 }
 
-CardScript.propTypes = {
+ScriptButton.propTypes = {
    classes: PropTypes.object.isRequired,
    script: PropTypes.object.isRequired,
    heroPlayer: PropTypes.string.isRequired,
    activeCard: PropTypes.object.isRequired,
-   variant: PropTypes.string
+   variant: PropTypes.string,
+   focus: PropTypes.bool,
 };
 
-CardScript.contextType = WebSocketContext;
+ScriptButton.contextType = WebSocketContext;
 
 export default connect(mapStateToProps, { filterDeck, moveCard, createTokens, millUntil, banishAll, addMessage, discardAndDraw })(
-   withStyles(styles)(CardScript)
+   withStyles(styles)(ScriptButton)
 );


### PR DESCRIPTION
Like with preprop, quicker to be able to select card and just press Enter than navigate back to script button (gave prepop priority though in case theres both, as LP usually needs to be done first for cost).

One thing I can't really figure out is why sometimes giving the button focus results in the MUI ripple effect pulsing and not other times:

![Screen Shot 2021-08-28 at 10 26 59](https://user-images.githubusercontent.com/117249/131225950-c1ff73ad-8d06-44aa-a631-312b55274016.png)

It's perhaps actually a feature when it highlights the script button, as I think it helps a lot with discoverability of scripts (which is crucial given they're literally required to be able to play), but that fact that it is inconsistent (the button always seems to focus which is good, but only sometimes does the focus result in a pulsing ripple effect) is kind of annoying.
