### PR TITLE
Add concede dialog/fix queue button alert

### DIFF
--- a/web-app/src/views/Game/Battlefield/RightTools/StandardTools/ConcedeButton.js
+++ b/web-app/src/views/Game/Battlefield/RightTools/StandardTools/ConcedeButton.js
@@ -1,20 +1,64 @@
-import React, { PureComponent } from "react";
+import React, { PureComponent, Fragment } from "react";
 import { connect } from "react-redux";
+
+import Dialog from '@material-ui/core/Dialog';
+import DialogActions from '@material-ui/core/DialogActions';
+import DialogContent from '@material-ui/core/DialogContent';
+import DialogContentText from '@material-ui/core/DialogContentText';
+import DialogTitle from '@material-ui/core/DialogTitle';
 
 import Button from "components/CustomButtons/Button.js";
 import { WebSocketContext } from "views/Game/WebSocketContext";
 import { PLAYER_CONCEDED, CLEANUP_GAME } from "shared/constants.js";
 
 class ConcedeButton extends PureComponent {
+   constructor(props) {
+      super(props);
+      this.state = { dialogOpen: false };
+   }
+
+   handleDialogOpen = () => {
+      this.setState({ dialogOpen: true });
+   };
+
+   handleDialogClose = (ok) => {
+      this.setState({ dialogOpen: false });
+      if (ok) concedeGame(this.context);
+   };
+
    render() {
       const { concessionLink } = this.props;
+      const { dialogOpen } = this.state;
       const color = concessionLink ? "primary" : "rose";
-      const func = concessionLink ? () => quitGame(this.context) : () => concedeGame(this.context);
+      const func = concessionLink ? () => quitGame(this.context) : this.handleDialogOpen;
 
       return (
-         <Button color={color} round href={concessionLink ? concessionLink : undefined} onClick={func} style={{ marginBottom: "15px" }}>
-            {concessionLink ? "Quit" : "Concede Duel"}
-         </Button>
+         <Fragment>
+            <Button color={color} round href={concessionLink ? concessionLink : undefined} onClick={func} style={{ marginBottom: "15px" }}>
+               {concessionLink ? "Quit" : "Concede Duel"}
+            </Button>
+            <Dialog
+               open={dialogOpen}
+               onClose={this.handleDialogClose}
+               aria-labelledby="alert-dialog-title"
+               aria-describedby="alert-dialog-description"
+               >
+               <DialogTitle id="alert-dialog-title">Concede Duel</DialogTitle>
+               <DialogContent>
+                  <DialogContentText id="alert-dialog-description">
+                     Are you sure you wish to concede?
+                  </DialogContentText>
+               </DialogContent>
+               <DialogActions>
+                  <Button onClick={() => this.handleDialogClose(true)} color="primary">
+                     Yes
+                  </Button>
+                  <Button onClick={() => this.handleDialogClose(false)} color="primary" autoFocus>
+                     No
+                  </Button>
+               </DialogActions>
+            </Dialog>
+         </Fragment>
       );
    }
 }

--- a/web-app/src/views/LeaguePage/QueueButton.js
+++ b/web-app/src/views/LeaguePage/QueueButton.js
@@ -1,6 +1,12 @@
 import React, { PureComponent, Fragment } from "react";
 import PropTypes from "prop-types";
 
+import Dialog from '@material-ui/core/Dialog';
+import DialogActions from '@material-ui/core/DialogActions';
+import DialogContent from '@material-ui/core/DialogContent';
+import DialogContentText from '@material-ui/core/DialogContentText';
+import DialogTitle from '@material-ui/core/DialogTitle';
+
 import Shadow from "components/Shadow/Shadow.js";
 import Button from "components/CustomButtons/Button.js";
 import verifyDecks from "shared/verifyDecks.js";
@@ -9,10 +15,11 @@ import { getAuthHeaders } from "utils/authToken.js";
 import getApiStage from "utils/getApiStage.js";
 import { LEAGUE_SOCKET_URL, ENTER_QUEUE, NEW_GAME } from "shared/constants.js";
 
+
 class QueueButton extends PureComponent {
    constructor(props) {
       super(props);
-      this.state = { webSocket: false };
+      this.state = { webSocket: false, dialogOpen: false };
 
       const storage = window.sessionStorage;
       const activeDeck = storage.getItem("activeDeck");
@@ -49,13 +56,22 @@ class QueueButton extends PureComponent {
       this.state.webSocket.close();
    };
 
-   displayErrors = () => {
-      // TODO: replace this with a Dialog instead of an alert
-      alert(this.errors.join("\n"));
+   handleDialogOpen = () => {
+      this.setState({ dialogOpen: true });
+   };
+
+   handleDialogClose = () => {
+      this.setState({ dialogOpen: false });
    };
 
    render() {
-      const { webSocket } = this.state;
+      const { webSocket, dialogOpen } = this.state;
+
+      const errors = this.errors.map((error, index) =>
+         <li key={index}>
+            {error}
+         </li>
+      );
 
       return (
          <Fragment>
@@ -64,9 +80,29 @@ class QueueButton extends PureComponent {
                   Click to {webSocket ? "Leave" : "Enter"} the Matchmaking Queue
                </Button>
             ) : (
-               <Button color="warning" size="lg" round onClick={this.displayErrors}>
-                  Illegal Deck
-               </Button>
+               <Fragment>
+                  <Button color="warning" size="lg" round onClick={this.handleDialogOpen}>
+                     Illegal Deck
+                  </Button>
+                  <Dialog
+                     open={dialogOpen}
+                     onClose={this.handleDialogClose}
+                     aria-labelledby="alert-dialog-title"
+                     aria-describedby="alert-dialog-description"
+                     >
+                     <DialogTitle id="alert-dialog-title">Errors</DialogTitle>
+                     <DialogContent>
+                        <DialogContentText id="alert-dialog-description">
+                           <ul>{errors}</ul>
+                        </DialogContentText>
+                     </DialogContent>
+                     <DialogActions>
+                        <Button onClick={this.handleDialogClose} color="primary" autoFocus>
+                           OK
+                        </Button>
+                     </DialogActions>
+                  </Dialog>
+               </Fragment>
             )}
             {webSocket && <Shadow>Finding you a match...</Shadow>}
          </Fragment>


### PR DESCRIPTION
Relatively popular proposal:

<img width="839" alt="Screen Shot 2021-08-28 at 13 16 24" src="https://user-images.githubusercontent.com/117249/131230034-35b4ea3b-2d64-4122-adbd-00639ee55cd3.png">

![Screen Shot 2021-08-28 at 13 14 29](https://user-images.githubusercontent.com/117249/131230035-51a25761-92c7-4f25-b985-a89749652e07.png)

Also cleans up the ugly `alert` from #234:

![Screen Shot 2021-08-28 at 12 53 28](https://user-images.githubusercontent.com/117249/131230051-2ab6bbb7-5bc1-4b03-b134-82d8596584c3.png)

Mostly just copied the code from https://material-ui.com/components/dialogs/
