### PR TITLE
Add Deck Constructor support for alternative art

### DIFF
--- a/web-app/src/views/DeckConstructor/LeftPanel/CardSearch.js
+++ b/web-app/src/views/DeckConstructor/LeftPanel/CardSearch.js
@@ -15,6 +15,7 @@ import {
    RITUAL_MONSTER,
    SPELL,
    SPELL_TRAP,
+   SENTINEL,
    TRAP,
    allSubtypes,
    spellSubtypes,
@@ -96,7 +97,13 @@ class CardSearch extends PureComponent {
    setDefStart = (event) => this.setNumberParam(event, ">", "def");
    setDefEnd = (event) => this.setNumberParam(event, "<", "def2");
 
-   getResults = (value) => this.props.newResults([value]);
+   getResults = (name) => {
+      const results = [];
+      for (let i = 0; i < (nonfusions[name].art || 1); i++) {
+         results.push(i > 0 ? `${name}${SENTINEL}${i}` : name);
+      }
+      return this.props.newResults(results);
+   };
 
    search = () => {
       const { params } = this.state;
@@ -104,7 +111,11 @@ class CardSearch extends PureComponent {
 
       for (const cardName in nonfusions) {
          const { fail } = checkParams({ name: cardName }, params);
-         if (fail.length === 0) results.push(cardName);
+         if (fail.length === 0) {
+            for (let i = 0; i < (nonfusions[cardName].art || 1); i++) {
+               results.push(i > 0 ? `${cardName}${SENTINEL}${i}` : cardName);
+            }
+         }
       }
 
       this.props.newResults(results);

--- a/web-app/src/views/DeckConstructor/RightPanel/SearchResults/CardsToRender.js
+++ b/web-app/src/views/DeckConstructor/RightPanel/SearchResults/CardsToRender.js
@@ -6,6 +6,7 @@ import RenderCards from "components/RenderCards/RenderCards.js";
 import { newResults } from "stateStore/actions/deckConstructor/searchResults.js";
 import { SizeContext } from "components/ResizableContainer/ResizableContainer.js";
 import getCardDetails from "shared/getCardDetails";
+import { SENTINEL } from "shared/constants.js";
 
 class CardsToRender extends Component {
    componentDidUpdate() {
@@ -17,9 +18,10 @@ class CardsToRender extends Component {
       const { searchResults, maindeck, sidedeck } = this.props;
       const cardsToRender = [];
 
-      for (const cardName of searchResults) {
-         const quantity = (getCardDetails(cardName).limit || 3) - (maindeck[cardName] || 0) - (sidedeck[cardName] || 0);
-         if (quantity > 0) cardsToRender.push({ name: cardName, quantity });
+      for (const name of searchResults) {
+         const cardName = name.split(SENTINEL)[0];
+         const quantity = (getCardDetails(cardName).limit || 3) - (deduped(maindeck)[cardName] || 0) - (deduped(sidedeck)[cardName] || 0);
+         if (quantity > 0) cardsToRender.push({ name, quantity });
       }
 
       return cardsToRender;
@@ -33,6 +35,15 @@ class CardsToRender extends Component {
 
       return <RenderCards cardsToRender={cardsToRender} maxHeight={maxHeight} cardHeight={cardHeight} player={player} decklist />;
    }
+}
+
+function deduped(deck) {
+   const names = {};
+   for (const raw in deck) {
+      const name = raw.split(SENTINEL)[0];
+      names[name] = (names[name] ? names[name] + deck[raw] : deck[raw]);
+   }
+   return names;
 }
 
 function mapStateToProps(state) {


### PR DESCRIPTION
Also fixes card limit verification in `verifyDecks`.

I went with the "DuelingBook approach" which [I don't particularly love](https://github.com/acpennington/GoatController/pull/234#issuecomment-900775533), but was by far the most straightforward way to implement things.

 #232

![Screen Shot 2021-08-28 at 15 22 03](https://user-images.githubusercontent.com/117249/131232475-e8e204c2-080d-453e-a72e-ac1d2b96841c.png)
