### PR TITLE
Add field shortcuts selection (and counters)

### DIFF
--- a/web-app/src/views/Game/Battlefield/RightTools/StandardTools/Counters.js
+++ b/web-app/src/views/Game/Battlefield/RightTools/StandardTools/Counters.js
@@ -14,11 +14,13 @@ import { onField } from "shared/constants.js";
 class Counters extends Component {
    componentDidMount() {
       bind("=", () => this.tryAdjustCounters(1));
+      bind("+", () => this.tryAdjustCounters(1));
       bind("-", () => this.tryAdjustCounters(-1));
+      bind("_", () => this.tryAdjustCounters(-1));
    }
 
    componentWillUnmount() {
-      unbind(["=", "-"]);
+      unbind(["=", "+", "-", "_"]);
    }
 
    shouldComponentUpdate() {


### PR DESCRIPTION
Fixes #252.

Ultimately my initial idea of logically giving the 10 monster/spell trap cells static labels turned out to be less than intuitive when I actually tried to use it as a player, so instead I went with a dynamic approach, where cards are assigned shortcuts from left->right & top->bottom. These ends up being much more intuitive (and means that for Library FTK you usually only need to worry about hitting `1` to select your Royal Magical Library as its likely your only monster, as opposed to having to remember which column you placed it in).

I feel this is a super power-user feature, but damn if it isn't nice. Let's prioritize getting Convulsion of Nature done so I can speedrun Solitaire: Goat Format Edition!