### PR TITLE
Support cards with more than one script

### DIFF
--- a/shared/database.test.js
+++ b/shared/database.test.js
@@ -35,7 +35,7 @@ const EFFECTS = [...MONSTER_EFFECTS, ...OTHER_EFFECTS];
 
 const SPELL_TRAP_REQUIRED = ["id", "cardType", "levelOrSubtype", "text"];
 const MONSTER_REQUIRED = ["id", "cardType", "attribute", "levelOrSubtype", "atk", "def", "text"];
-const OPTIONAL = ["prepopLP", "script", "limit", "art"];
+const OPTIONAL = ["prepopLP", "script", "script2", "limit", "art"];
 const TOKEN_REQUIRED = MONSTER_REQUIRED.slice(1);
 const FUSION_OPTIONAL = ["order", "noMeta", ...OPTIONAL];
 
@@ -387,21 +387,22 @@ test("database", () => {
          }
       }
 
-      const script = card.script;
-      if (script) {
-         expectFields(`"${name}" script.displayCondition`, script, [], ["name", "tooltip", "displayCondition", "params", "oneParam", "autoClose"]);
-         expect(scriptNames).toContain(script.name);
-         if (script.tooltip) expect(script.tooltip.length).toBeGreaterThan(0);
-         expectFields(`"${name}" script.displayCondition`, script.displayCondition, ["players", "row"]);
-         expect(allZones).toContain(script.displayCondition.row);
+      for (const script of [card.script, card.script2]) {
+         if (script) {
+            expectFields(`"${name}" script.displayCondition`, script, [], ["name", "tooltip", "displayCondition", "params", "oneParam", "autoClose"]);
+            expect(scriptNames).toContain(script.name);
+            if (script.tooltip) expect(script.tooltip.length).toBeGreaterThan(0);
+            expectFields(`"${name}" script.displayCondition`, script.displayCondition, ["players", "row"]);
+            expect(allZones).toContain(script.displayCondition.row);
 
-         const players = JSON.stringify(script.displayCondition.players);
-         expect(['["HERO"]', '["VILLAIN"]', '["HERO","VILLAIN"]'].includes(players), `"${name}" has an invalid script.displayConditions.players: "${players}"`).toBe(true);
+            const players = JSON.stringify(script.displayCondition.players);
+            expect(['["HERO"]', '["VILLAIN"]', '["HERO","VILLAIN"]'].includes(players), `"${name}" has an invalid script.displayConditions.players: "${players}"`).toBe(true);
 
-         verifyScriptParams(name, script);
+            verifyScriptParams(name, script);
 
-         expect([undefined, true].includes(script.oneParam)).toBe(true);
-         expect([undefined, true].includes(script.autoClose)).toBe(true);
+            expect([undefined, true].includes(script.oneParam)).toBe(true);
+            expect([undefined, true].includes(script.autoClose)).toBe(true);
+         }
       }
 
       expect([undefined, 1, 2].includes(card.limit), `"${name}" has an invalid limit: '${card.limit}'`).toBe(true);

--- a/shared/db.json
+++ b/shared/db.json
@@ -3498,6 +3498,11 @@
          "name": "RANDOM_DISCARD",
          "displayCondition": { "players": ["VILLAIN"], "row": "monster" }
       },
+      "script2": {
+         "name": "MILL_UNTIL",
+         "displayCondition": { "players": ["VILLAIN"], "row": "monster" },
+         "params": 2
+      },
       "art": 2
    },
    "Dora of Fate": {
@@ -4623,6 +4628,30 @@
       "def": 1200,
       "text": "Warrior/Effect – <effect=Ignition>Once per turn: You can banish 2 LIGHT monsters from your Graveyard, then target 1 face-up monster on the field with higher ATK than this card; destroy that target.</effect>"
    },
+   "Freed the Matchless General": {
+      "id": "49681811",
+      "cardType": "effectMonster",
+      "attribute": "Earth",
+      "levelOrSubtype": 5,
+      "atk": 2300,
+      "def": 1700,
+      "text": "Warrior/Effect – <effect=Continuous>Negate any Spell effects that target this card, and if you do, destroy that Spell.</effect> <effect=Trigger>During your Draw Phase, instead of conducting your normal draw: You can add 1 Level 4 or lower Warrior monster from your Deck to your hand. This card must be face-up on the field to activate and to resolve this effect.</effect>",
+      "script": {
+         "name": "SKIP_DRAWS",
+         "tooltip": "Activate in opponent's End Phase if you plan to search next Draw Phase",
+         "displayCondition": { "players": ["HERO"], "row": "monster" },
+         "params": 1
+      },
+      "script2": {
+         "name": "SEARCH_DECK",
+         "displayCondition": { "players": ["HERO"], "row": "monster" },
+         "params": {
+            "levelOrSubtype": { "operator": "<", "value": 4 },
+            "text": { "operator": "TYPEMATCH", "value": "Warrior" }
+         },
+         "autoClose": true
+      }
+   },
    "Freezing Beast": {
       "id": "85359414",
       "cardType": "effectMonster",
@@ -4670,6 +4699,11 @@
       "script": {
          "name": "RANDOM_DISCARD",
          "displayCondition": { "players": ["VILLAIN"], "row": "spellTrap" },
+         "params": 2
+      },
+      "script2": {
+         "name": "DRAW_N",
+         "displayCondition": { "players": ["HERO"], "row": "spellTrap" },
          "params": 2
       }
    },
@@ -4813,6 +4847,22 @@
       "atk": 1400,
       "def": 700,
       "text": "Reptile/Flip/Effect – <effect=Trigger>FLIP: Target 1 monster your opponent controls; return that target to the hand.</effect>"
+   },
+   "Gamble": {
+      "id": "37313786",
+      "cardType": "Trap",
+      "levelOrSubtype": "Normal",
+      "text": "If your opponent has 6 or more cards in their hand, while you have 2 or less cards in your hand: Toss a coin and call it. If you call it right, draw until you have 5 cards in your hand. If you call it wrong, skip your next turn.",
+      "script": {
+         "name": "FLIP_COINS",
+         "displayCondition": { "players": ["HERO"], "row": "spellTrap" },
+         "params": 1
+      },
+      "script2": {
+         "name": "SKIP_DRAWS",
+         "displayCondition": { "players": ["HERO"], "row": "spellTrap" },
+         "params": 1
+      }
    },
    "Gamma The Magnet Warrior": {
       "id": "11549357",
@@ -10261,6 +10311,11 @@
          "displayCondition": { "players": ["HERO"], "row": "spellTrap" },
          "params": 2
       },
+      "script2": {
+         "name": "DRAW_N",
+         "displayCondition": { "players": ["HERO"], "row": "spellTrap" },
+         "params": 2
+      },
       "limit": 1
    },
    "Red Archery Girl": {
@@ -13297,6 +13352,12 @@
          "name": "FLIP_COINS",
          "displayCondition": { "players": ["HERO"], "row": "monster" },
          "params": 1
+      },
+      "script2": {
+         "name": "SEARCH_DECK",
+         "displayCondition": { "players": ["HERO"], "row": "monster" },
+         "params": { "name": { "value": "Dark Sage" } },
+         "autoClose": true
       }
    },
    "Timeater": {

--- a/web-app/src/components/CardScript/CardScript.js
+++ b/web-app/src/components/CardScript/CardScript.js
@@ -44,19 +44,25 @@ class CardScript extends PureComponent {
 
       if (!cardName) return null;
 
-      const { cardType, text, script, prepopLP } = getCardDetails(cardName);
+      const { cardType, text, script, script2, prepopLP } = getCardDetails(cardName);
       const focus = !(prepopLP && (player === heroPlayer ? prepopLP.hero : prepopLP.villain));
+
+      const validScript = script && this.validScript(activeCard, player, script);
+      const validScript2 = script2 && this.validScript(activeCard, player, script2);
 
       return (
          <Fragment>
-            {script && this.validScript(activeCard, player, script) && (
+            {validScript && (
                <ScriptButton script={script} heroPlayer={heroPlayer} cardName={cardName} activeCard={activeCard} focus={focus} />
             )}
+            {validScript2 && (
+               <ScriptButton script={script2} heroPlayer={heroPlayer} cardName={cardName} activeCard={activeCard} focus={focus && !validScript} />
+            )}
             {[BANISHED, MONSTER].includes(activeCard.row) && text.includes("/Flip/") && (
-               <ScriptButton script={{ name: BANISH_ALL }} variant="Nobleman of Crossout" activeCard={activeCard} heroPlayer={heroPlayer} focus={focus} />
+               <ScriptButton script={{ name: BANISH_ALL }} variant="Nobleman of Crossout" activeCard={activeCard} heroPlayer={heroPlayer} focus={focus && !validScript && !validScript2} />
             )}
             {[BANISHED, SPELL_TRAP].includes(activeCard.row) && cardType === TRAP && (
-               <ScriptButton script={{ name: BANISH_ALL }} variant="Nobleman of Extermination" activeCard={activeCard} heroPlayer={heroPlayer} focus={focus} />
+               <ScriptButton script={{ name: BANISH_ALL }} variant="Nobleman of Extermination" activeCard={activeCard} heroPlayer={heroPlayer} focus={focus && !validScript && !validScript2} />
             )}
          </Fragment>
       );


### PR DESCRIPTION
Also makes sure focus gets assigned to the correct script button (the top-most script is assumed to be primary as opposed to previously where the bottom script would usually win)

#282