### PR TITLE
Implement BANISH_ALL for Chain Destruction/Disappearance

### DIFF
--- a/shared/db.json
+++ b/shared/db.json
@@ -1918,21 +1918,13 @@
       "id": "01248895",
       "cardType": "Trap",
       "levelOrSubtype": "Normal",
-      "text": "When a monster(s) with 2000 or less ATK is Summoned: Target 1 of them; destroy all cards with that name in its controller's hand and Deck.",
-      "script": {
-         "name": "SEARCH_DECK",
-         "displayCondition": { "players": ["VILLAIN"], "row": "spellTrap" }
-      }
+      "text": "When a monster(s) with 2000 or less ATK is Summoned: Target 1 of them; destroy all cards with that name in its controller's hand and Deck."
    },
    "Chain Disappearance": {
       "id": "57139487",
       "cardType": "Trap",
       "levelOrSubtype": "Normal",
-      "text": "When a monster(s) with 1000 or less ATK is Summoned: Banish that monster(s) with 1000 or less ATK, then your opponent banishes all cards with the same name as that card(s) from their hand and Deck.",
-      "script": {
-         "name": "SEARCH_DECK",
-         "displayCondition": { "players": ["VILLAIN"], "row": "spellTrap" }
-      }
+      "text": "When a monster(s) with 1000 or less ATK is Summoned: Banish that monster(s) with 1000 or less ATK, then your opponent banishes all cards with the same name as that card(s) from their hand and Deck."
    },
    "Chain Energy": {
       "id": "79323590",

--- a/web-app/src/components/CardScript/CardScript.js
+++ b/web-app/src/components/CardScript/CardScript.js
@@ -44,7 +44,7 @@ class CardScript extends PureComponent {
 
       if (!cardName) return null;
 
-      const { cardType, text, script, script2, prepopLP } = getCardDetails(cardName);
+      const { cardType, atk, text, script, script2, prepopLP } = getCardDetails(cardName);
       const focus = !(prepopLP && (player === heroPlayer ? prepopLP.hero : prepopLP.villain));
 
       const validScript = script && this.validScript(activeCard, player, script);
@@ -63,6 +63,12 @@ class CardScript extends PureComponent {
             )}
             {[BANISHED, SPELL_TRAP].includes(activeCard.row) && cardType === TRAP && (
                <ScriptButton script={{ name: BANISH_ALL }} variant="Nobleman of Extermination" activeCard={activeCard} heroPlayer={heroPlayer} focus={focus && !validScript && !validScript2} />
+            )}
+             {[BANISHED, MONSTER].includes(activeCard.row) && cardType.includes("Monster") && atk <= 2000 && (
+               <ScriptButton script={{ name: BANISH_ALL, params: true }} variant="Chain Destruction" activeCard={activeCard} heroPlayer={heroPlayer} focus={focus && !validScript && !validScript2} />
+            )}
+            {[BANISHED, MONSTER].includes(activeCard.row) && cardType.includes("Monster") && atk <= 1000 && (
+               <ScriptButton script={{ name: BANISH_ALL, params: true }} variant="Chain Disappearance" activeCard={activeCard} heroPlayer={heroPlayer} focus={focus && !validScript && !validScript2} />
             )}
          </Fragment>
       );

--- a/web-app/src/components/CardScript/ScriptButton.js
+++ b/web-app/src/components/CardScript/ScriptButton.js
@@ -67,7 +67,7 @@ class ScriptButton extends PureComponent {
             filterDeck(heroPlayer, script);
             break;
          case BANISH_ALL:
-            banishAll(field, heroPlayer, activeCard, variant, socket);
+            banishAll(field, heroPlayer, activeCard, variant, params, socket);
             break;
          case MILL_UNTIL:
             millUntil(heroPlayer, this.props.field[heroPlayer].deck, params, socket);
@@ -186,7 +186,7 @@ class ScriptButton extends PureComponent {
             onClick={this.runScript}
             style={
                activeCard && activeCard.name
-                  ? { backgroundImage: 'linear-gradient(rgba(0, 0, 0, 0.75), rgba(0, 0, 0, 0.75)), url("/cards/art/' + compress(activeCard.name) + '.jpg")' }
+                  ? { backgroundImage: 'linear-gradient(rgba(0, 0, 0, 0.75), rgba(0, 0, 0, 0.75)), url("/cards/art/' + compress(variant || activeCard.name) + '.jpg")' }
                   : {}
             }
             round
@@ -209,6 +209,8 @@ function fieldContains(field, card) {
    switch (card) {
       case "Nobleman of Extermination":
       case "Nobleman of Crossout":
+      case "Chain Destruction":
+      case "Chain Disappearance":
          for (const key in field) for (const zone of field[key][SPELL_TRAP]) if (zone && !zone.facedown && zone.name === card) return true;
          return false;
       default:


### PR DESCRIPTION
Trying to figure out how to banish from the fusion deck (which according to the rulings [here](https://www.formatlibrary.com/goat-rulings/chain-disappearance) and [here](https://www.goatformat.com/rulings1.html) is how it works :S) took a while, but from my testing i think its working. Ultimately - yeah, these cards need scripts. Resolving this with just SEARCH_DECK is pretty difficult.